### PR TITLE
Refactor UI into per-mode leaderboards with map selection

### DIFF
--- a/index.php
+++ b/index.php
@@ -234,7 +234,8 @@ try {
 
     .tab-header {
       display: inline-flex;
-      gap: 12px;
+      flex-wrap: wrap;
+      gap: 8px;
       padding: 6px;
       border-radius: 16px;
       background: rgba(255, 255, 255, 0.06);
@@ -247,11 +248,12 @@ try {
       border: none;
       background: transparent;
       color: var(--text-muted);
-      padding: 10px 18px;
+      padding: 8px 14px;
       border-radius: 12px;
       font-weight: 600;
       letter-spacing: 0.04em;
       text-transform: uppercase;
+      font-size: 0.78rem;
       transition: background 140ms ease, color 140ms ease, box-shadow 140ms ease;
     }
 
@@ -274,6 +276,120 @@ try {
 
     .tab-panel.active {
       display: flex;
+    }
+
+    #modePanels {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .mode-panel {
+      display: none;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .mode-panel.active {
+      display: flex;
+    }
+
+    .mode-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 18px;
+      align-items: flex-end;
+    }
+
+    .mode-controls label {
+      display: block;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 6px;
+    }
+
+    .mode-controls select {
+      appearance: none;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: rgba(9, 12, 20, 0.85);
+      color: var(--text);
+      padding: 10px 14px;
+      font-size: 0.95rem;
+      min-width: 220px;
+    }
+
+    .mode-layout {
+      display: grid;
+      grid-template-columns: minmax(220px, 320px) 1fr;
+      gap: 24px;
+      align-items: flex-start;
+    }
+
+    .mode-levelshot {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      align-items: center;
+      padding: 16px;
+      border-radius: 18px;
+      background: rgba(10, 15, 26, 0.68);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .mode-levelshot img {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(255, 255, 255, 0.03);
+      aspect-ratio: 4 / 3;
+      object-fit: cover;
+    }
+
+    .mode-levelshot figcaption {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      text-align: center;
+    }
+
+    .mode-levelshot-fallback {
+      margin: 0;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      text-align: center;
+    }
+
+    .mode-meta {
+      display: grid;
+      gap: 6px;
+      width: 100%;
+    }
+
+    .mode-meta span {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .mode-meta strong {
+      font-size: 1rem;
+      color: var(--text);
+    }
+
+    .mode-table-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .mode-table-wrapper h3 {
+      margin: 0;
+      font-size: 0.85rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--text-muted);
     }
 
     .table-wrapper {
@@ -370,7 +486,7 @@ try {
 
     select,
     input[type="search"],
-    button {
+    button:not(.tab-button) {
       width: 100%;
       padding: 12px 14px;
       border-radius: 14px;
@@ -382,12 +498,12 @@ try {
 
     select:focus,
     input[type="search"]:focus,
-    button:focus {
+    button:not(.tab-button):focus {
       outline: 2px solid var(--accent);
       outline-offset: 2px;
     }
 
-    button {
+    button:not(.tab-button) {
       cursor: pointer;
       background: linear-gradient(135deg, var(--accent), rgba(125, 167, 255, 0.9));
       border: 1px solid rgba(93, 139, 255, 0.5);
@@ -395,7 +511,7 @@ try {
       transition: transform 120ms ease, box-shadow 120ms ease;
     }
 
-    button:hover {
+    button:not(.tab-button):hover {
       transform: translateY(-1px);
       box-shadow: 0 14px 32px rgba(93, 139, 255, 0.25);
     }
@@ -610,6 +726,19 @@ try {
         padding: 24px 14px 38px;
       }
 
+      .tab-header {
+        width: 100%;
+        justify-content: center;
+      }
+
+      .mode-layout {
+        grid-template-columns: 1fr;
+      }
+
+      .mode-controls select {
+        min-width: 0;
+        width: 100%;
+      }
 
       .hero-top {
         flex-direction: column;
@@ -660,7 +789,7 @@ try {
           <img src="logo.png" alt="Q3Rally Logo" onerror="this.style.display='none'">
           <div class="hero-info">
             <h1 data-i18n-html="hero.title">Q3Rally Ladder Monitor <span class="badge-beta">beta</span></h1>
-            <p data-i18n-html="hero.description">Direkte Vorschau aller gespeicherten Matches aus dem <code>data/</code>-Ordner. Vergleiche Bestzeiten aus Renn-Modi oder filtere in der Matchübersicht nach Maps, IDs und Spielern – inklusive vollständiger JSON-Details.</p>
+            <p data-i18n-html="hero.description">Direkte Vorschau der besten Platzierungen je Spielmodus und Map. Wähle oben einen Modus und vergleiche die Top 10 pro Strecke – inklusive Levelshot-Vorschau.</p>
           </div>
         </div>
         <div class="language-toggle" role="group" aria-label="Sprachauswahl" data-i18n-aria-label="language.toggleLabel">
@@ -680,200 +809,9 @@ try {
     </section>
 
     <section class="panel tabbed-panel">
-      <div class="tab-header" role="tablist" aria-label="Ansichten" data-i18n-aria-label="tabs.label">
-        <button class="tab-button" id="tab-button-matches" role="tab" aria-selected="false" aria-controls="tab-matches" data-tab="matches" data-i18n="tabs.matches">Matchübersicht</button>
-        <button class="tab-button active" id="tab-button-leaderboard" role="tab" aria-selected="true" aria-controls="tab-leaderboard" data-tab="leaderboard" data-i18n="tabs.racing">RACING LEADERBOARD</button>
-        <button class="tab-button" id="tab-button-deathmatch" role="tab" aria-selected="false" aria-controls="tab-deathmatch" data-tab="deathmatch" data-i18n="tabs.deathmatch">DEATHMATCH LEADERBOARD</button>
-        <button class="tab-button" id="tab-button-elimination" role="tab" aria-selected="false" aria-controls="tab-elimination" data-tab="elimination" data-i18n="tabs.elimination">ELIMINATION LEADERBOARD</button>
-        <button class="tab-button" id="tab-button-ctf" role="tab" aria-selected="false" aria-controls="tab-ctf" data-tab="ctf" data-i18n="tabs.ctf">CTF LEADERBOARD</button>
-      </div>
-
-      <div class="tab-panel" id="tab-matches" role="tabpanel" aria-labelledby="tab-button-matches">
-        <div class="controls match-controls">
-          <div>
-            <label for="modeFilter" data-i18n="filters.matches.mode.label">Spielmodus</label>
-            <select id="modeFilter">
-              <option value="__all" data-i18n="filters.matches.mode.all">Alle Modi</option>
-            </select>
-          </div>
-          <div>
-            <label for="searchInput" data-i18n="filters.matches.search.label">Suche</label>
-            <input type="search" id="searchInput" placeholder="Match-ID, Map oder Spieler…" autocomplete="off" data-i18n-placeholder="filters.matches.search.placeholder">
-          </div>
-          <div>
-            <label for="limitSelect" data-i18n="filters.matches.limit.label">Lade-Limit</label>
-            <select id="limitSelect">
-              <option value="100" selected>100</option>
-              <option value="250">250</option>
-              <option value="500">500</option>
-              <option value="all" data-i18n="filters.matches.limit.all">Alle</option>
-            </select>
-          </div>
-          <div>
-            <label>&nbsp;</label>
-            <button id="refreshButton" type="button" data-i18n="filters.matches.refresh">Aktualisieren</button>
-            <p class="status" id="statusMessage"></p>
-          </div>
-        </div>
-        <div id="matches" aria-live="polite"></div>
-        <noscript>
-          <p class="empty-state" data-i18n="noscript.message">Bitte JavaScript aktivieren, um die gespeicherten Matches anzeigen zu können.</p>
-        </noscript>
-      </div>
-
-      <div class="tab-panel active" id="tab-leaderboard" role="tabpanel" aria-labelledby="tab-button-leaderboard">
-        <div class="controls leaderboard-controls">
-          <div>
-            <label for="leaderboardModeFilter" data-i18n="filters.leaderboard.mode.label">Spielmodus</label>
-            <select id="leaderboardModeFilter">
-              <option value="__all" data-i18n="filters.leaderboard.mode.all">Alle Renn-Modi</option>
-            </select>
-          </div>
-          <div>
-            <label for="leaderboardMapFilter" data-i18n="filters.leaderboard.map.label">Map</label>
-            <select id="leaderboardMapFilter">
-              <option value="__all" data-i18n="filters.leaderboard.map.all">Alle Maps</option>
-            </select>
-          </div>
-          <div>
-            <label for="leaderboardPlayerSearch" data-i18n="filters.leaderboard.player.label">Spielersuche</label>
-            <input type="search" id="leaderboardPlayerSearch" placeholder="Spielername…" autocomplete="off" data-i18n-placeholder="filters.leaderboard.player.placeholder">
-          </div>
-        </div>
-        <p class="status" id="leaderboardStatus"></p>
-        <div class="table-wrapper" aria-live="polite">
-          <table class="leaderboard-table">
-            <thead>
-              <tr>
-                <th scope="col" data-i18n="leaderboard.headers.rank">Rang</th>
-                <th scope="col" data-i18n="leaderboard.headers.player">Spieler</th>
-                <th scope="col" data-i18n="leaderboard.headers.best">Bestzeit</th>
-                <th scope="col" data-i18n="leaderboard.headers.map">Map</th>
-                <th scope="col" data-i18n="leaderboard.headers.mode">Modus</th>
-                <th scope="col" data-i18n="leaderboard.headers.recorded">Aufgestellt am</th>
-              </tr>
-            </thead>
-            <tbody id="leaderboardBody"></tbody>
-          </table>
-        </div>
-        <p class="empty-state" id="leaderboardEmpty" hidden></p>
-      </div>
-
-      <div class="tab-panel" id="tab-deathmatch" role="tabpanel" aria-labelledby="tab-button-deathmatch">
-        <div class="controls leaderboard-controls">
-          <div>
-            <label for="deathmatchModeFilter" data-i18n="filters.deathmatch.mode.label">Spielmodus</label>
-            <select id="deathmatchModeFilter">
-              <option value="__all" data-i18n="filters.deathmatch.mode.all">Alle Deathmatch-Modi</option>
-            </select>
-          </div>
-          <div>
-            <label for="deathmatchMapFilter" data-i18n="filters.deathmatch.map.label">Map</label>
-            <select id="deathmatchMapFilter">
-              <option value="__all" data-i18n="filters.deathmatch.map.all">Alle Maps</option>
-            </select>
-          </div>
-          <div>
-            <label for="deathmatchPlayerSearch" data-i18n="filters.deathmatch.player.label">Spielersuche</label>
-            <input type="search" id="deathmatchPlayerSearch" placeholder="Spielername…" autocomplete="off" data-i18n-placeholder="filters.deathmatch.player.placeholder">
-          </div>
-        </div>
-        <p class="status" id="deathmatchStatus"></p>
-        <div class="table-wrapper" aria-live="polite">
-          <table class="leaderboard-table">
-            <thead>
-              <tr>
-                <th scope="col" data-i18n="deathmatch.headers.rank">Rang</th>
-                <th scope="col" data-i18n="deathmatch.headers.player">Spieler</th>
-                <th scope="col" data-i18n="deathmatch.headers.kdr">K/D</th>
-                <th scope="col" data-i18n="deathmatch.headers.kills">Kills</th>
-                <th scope="col" data-i18n="deathmatch.headers.deaths">Deaths</th>
-                <th scope="col" data-i18n="deathmatch.headers.map">Map</th>
-                <th scope="col" data-i18n="deathmatch.headers.mode">Modus</th>
-                <th scope="col" data-i18n="deathmatch.headers.recorded">Aufgestellt am</th>
-              </tr>
-            </thead>
-            <tbody id="deathmatchBody"></tbody>
-          </table>
-        </div>
-        <p class="empty-state" id="deathmatchEmpty" hidden></p>
-      </div>
-
-      <div class="tab-panel" id="tab-elimination" role="tabpanel" aria-labelledby="tab-button-elimination">
-        <div class="controls leaderboard-controls">
-          <div>
-            <label for="eliminationModeFilter" data-i18n="filters.elimination.mode.label">Spielmodus</label>
-            <select id="eliminationModeFilter">
-              <option value="__all" data-i18n="filters.elimination.mode.all">Alle Elimination-Modi</option>
-            </select>
-          </div>
-          <div>
-            <label for="eliminationMapFilter" data-i18n="filters.elimination.map.label">Map</label>
-            <select id="eliminationMapFilter">
-              <option value="__all" data-i18n="filters.elimination.map.all">Alle Maps</option>
-            </select>
-          </div>
-          <div>
-            <label for="eliminationPlayerSearch" data-i18n="filters.elimination.player.label">Spielersuche</label>
-            <input type="search" id="eliminationPlayerSearch" placeholder="Spielername…" autocomplete="off" data-i18n-placeholder="filters.elimination.player.placeholder">
-          </div>
-        </div>
-        <p class="status" id="eliminationStatus"></p>
-        <div class="table-wrapper" aria-live="polite">
-          <table class="leaderboard-table">
-            <thead>
-              <tr>
-                <th scope="col" data-i18n="elimination.headers.rank">Rang</th>
-                <th scope="col" data-i18n="elimination.headers.player">Spieler</th>
-                <th scope="col" data-i18n="elimination.headers.value">Wertung</th>
-                <th scope="col" data-i18n="elimination.headers.map">Map</th>
-                <th scope="col" data-i18n="elimination.headers.mode">Modus</th>
-                <th scope="col" data-i18n="elimination.headers.recorded">Aufgestellt am</th>
-              </tr>
-            </thead>
-            <tbody id="eliminationBody"></tbody>
-          </table>
-        </div>
-        <p class="empty-state" id="eliminationEmpty" hidden></p>
-      </div>
-
-      <div class="tab-panel" id="tab-ctf" role="tabpanel" aria-labelledby="tab-button-ctf">
-        <div class="controls leaderboard-controls">
-          <div>
-            <label for="ctfModeFilter" data-i18n="filters.ctf.mode.label">Spielmodus</label>
-            <select id="ctfModeFilter">
-              <option value="__all" data-i18n="filters.ctf.mode.all">Alle Objective-Modi</option>
-            </select>
-          </div>
-          <div>
-            <label for="ctfMapFilter" data-i18n="filters.ctf.map.label">Map</label>
-            <select id="ctfMapFilter">
-              <option value="__all" data-i18n="filters.ctf.map.all">Alle Maps</option>
-            </select>
-          </div>
-          <div>
-            <label for="ctfPlayerSearch" data-i18n="filters.ctf.player.label">Spielersuche</label>
-            <input type="search" id="ctfPlayerSearch" placeholder="Spielername…" autocomplete="off" data-i18n-placeholder="filters.ctf.player.placeholder">
-          </div>
-        </div>
-        <p class="status" id="ctfStatus"></p>
-        <div class="table-wrapper" aria-live="polite">
-          <table class="leaderboard-table">
-            <thead>
-              <tr>
-                <th scope="col" data-i18n="ctf.headers.rank">Rang</th>
-                <th scope="col" data-i18n="ctf.headers.player">Spieler</th>
-                <th scope="col" data-i18n="ctf.headers.value">Zielwertung</th>
-                <th scope="col" data-i18n="ctf.headers.map">Map</th>
-                <th scope="col" data-i18n="ctf.headers.mode">Modus</th>
-                <th scope="col" data-i18n="ctf.headers.recorded">Aufgestellt am</th>
-              </tr>
-            </thead>
-            <tbody id="ctfBody"></tbody>
-          </table>
-        </div>
-        <p class="empty-state" id="ctfEmpty" hidden></p>
-      </div>
+      <div class="tab-header" id="modeTabs" role="tablist" aria-label="Spielmodi" data-i18n-aria-label="tabs.label"></div>
+      <p class="status" id="modeStatus"></p>
+      <div id="modePanels" class="mode-panels"></div>
     </section>
 
     <section class="panel">
@@ -887,17 +825,31 @@ try {
   <script>
     const API_BASE = <?= json_encode($apiBase, JSON_UNESCAPED_SLASHES); ?>;
 
+    const MODE_CONFIG = [
+      { key: 'gt_racing', type: 'race' },
+      { key: 'gt_racing_dm', type: 'race' },
+      { key: 'gt_derby', type: 'objective' },
+      { key: 'gt_lcs', type: 'objective' },
+      { key: 'gt_elimination', type: 'objective' },
+      { key: 'gt_deathmatch', type: 'deathmatch' },
+      { key: 'gt_team', type: 'deathmatch' },
+      { key: 'gt_team_racing', type: 'race' },
+      { key: 'gt_team_racing_dm', type: 'race' },
+      { key: 'gt_ctf', type: 'objective' },
+      { key: 'gt_ctf4', type: 'objective' },
+      { key: 'gt_domination', type: 'objective' }
+    ];
 
     const I18N = {
       de: {
         'meta.title': 'Q3Rally Ladder Monitor beta',
         'meta.description': 'Frontend zur Auswertung der gespeicherten Q3Rally-Ladder-Matches.',
         'hero.title': 'Q3Rally Ladder Monitor <span class="badge-beta">beta</span>',
-        'hero.description': 'Direkte Vorschau aller gespeicherten Matches aus dem <code>data/</code>-Ordner. Vergleiche Bestzeiten aus Renn-Modi oder filtere in der Matchübersicht nach Maps, IDs und Spielern – inklusive vollständiger JSON-Details.',
+        'hero.description': 'Direkte Vorschau der besten Platzierungen je Spielmodus und Map. Wähle oben einen Modus und vergleiche die Top 10 pro Strecke – inklusive Levelshot-Vorschau.',
         'language.toggleLabel': 'Sprachauswahl',
         'language.deLabel': 'Deutsch',
         'language.enLabel': 'Englisch',
-        'tabs.label': 'Ansichten',
+        'tabs.label': 'Spielmodi',
         'tabs.racing': 'RACING LEADERBOARD',
         'tabs.deathmatch': 'DEATHMATCH LEADERBOARD',
         'tabs.elimination': 'ELIMINATION LEADERBOARD',
@@ -1030,17 +982,27 @@ try {
         'breakdown.empty': 'Keine Daten vorhanden.',
         'noscript.message': 'Bitte JavaScript aktivieren, um die gespeicherten Matches anzeigen zu können.',
         'mode.unknown': 'Unbekannt',
+        'mode.controls.map': 'Map',
+        'mode.table.heading': 'Top 10 Platzierungen',
+        'mode.empty': 'Keine Einträge für diese Map.',
+        'mode.status.loading': 'Lade Matches…',
+        'mode.status.ready': 'Top-Ergebnisse aus {count} Matches geladen.',
+        'mode.status.empty': 'Keine Matches gespeichert.',
+        'mode.status.error': 'Fehler beim Laden: {message}',
+        'mode.headers.metric': 'Metrik',
+        'mode.levelshot.missing': 'Kein Levelshot verfügbar.',
+        'map.unknown': 'Unbekannte Map',
         'common.unknown': 'Unbekannt'
       },
       en: {
         'meta.title': 'Q3Rally Ladder Monitor beta',
         'meta.description': 'Frontend for exploring the stored Q3Rally ladder matches.',
         'hero.title': 'Q3Rally Ladder Monitor <span class="badge-beta">beta</span>',
-        'hero.description': 'Live preview of every stored match from the <code>data/</code> folder. Compare best racing times or filter the match overview by maps, IDs, and players – complete with full JSON details.',
+        'hero.description': 'Live preview of the best placements per game mode and map. Pick a mode above and compare the top 10 per track – complete with levelshot previews.',
         'language.toggleLabel': 'Language selection',
         'language.deLabel': 'German',
         'language.enLabel': 'English',
-        'tabs.label': 'Views',
+        'tabs.label': 'Game modes',
         'tabs.racing': 'RACING LEADERBOARD',
         'tabs.deathmatch': 'DEATHMATCH LEADERBOARD',
         'tabs.elimination': 'ELIMINATION LEADERBOARD',
@@ -1173,6 +1135,16 @@ try {
         'breakdown.empty': 'No data available.',
         'noscript.message': 'Please enable JavaScript to display the stored matches.',
         'mode.unknown': 'Unknown',
+        'mode.controls.map': 'Map',
+        'mode.table.heading': 'Top 10 placements',
+        'mode.empty': 'No entries for this map.',
+        'mode.status.loading': 'Loading matches…',
+        'mode.status.ready': 'Loaded top entries from {count} matches.',
+        'mode.status.empty': 'No matches stored.',
+        'mode.status.error': 'Load error: {message}',
+        'mode.headers.metric': 'Metric',
+        'mode.levelshot.missing': 'No levelshot available.',
+        'map.unknown': 'Unknown map',
         'common.unknown': 'Unknown'
       }
     };
@@ -1209,8 +1181,8 @@ try {
     };
 
     const RACE_MODE_KEYS = new Set(['gt_racing', 'gt_racing_dm', 'gt_team_racing', 'gt_team_racing_dm']);
-    const DEATHMATCH_MODE_KEYS = new Set(['gt_deathmatch']);
-    const OBJECTIVE_MODE_KEYS = new Set(['gt_ctf', 'gt_ctf4', 'gt_elimination', 'gt_domination']);
+    const DEATHMATCH_MODE_KEYS = new Set(['gt_deathmatch', 'gt_team']);
+    const OBJECTIVE_MODE_KEYS = new Set(['gt_ctf', 'gt_ctf4', 'gt_elimination', 'gt_domination', 'gt_derby', 'gt_lcs']);
 
     const OBJECTIVE_METRIC_DEFINITIONS = {
       captures: {
@@ -1276,7 +1248,9 @@ try {
       gt_ctf: ['captures', 'score', 'objectives', 'wins'],
       gt_ctf4: ['captures', 'score', 'objectives', 'wins'],
       gt_elimination: ['wins', 'score', 'captures', 'objectives'],
-      gt_domination: ['objectives', 'score', 'captures', 'wins']
+      gt_domination: ['objectives', 'score', 'captures', 'wins'],
+      gt_derby: ['score', 'wins', 'objectives', 'captures'],
+      gt_lcs: ['wins', 'score', 'captures', 'objectives']
     };
 
     const OBJECTIVE_DEFAULT_PRIORITY = ['score', 'captures', 'objectives', 'wins'];
@@ -1289,1269 +1263,728 @@ try {
       value: 'ctf.metric.value'
     };
 
-    const state = {
-      allMatches: [],
-      filteredMatches: [],
-      limit: 100,
-      leaderboard: [],
-      filteredLeaderboard: [],
-      deathmatchLeaderboard: [],
-      filteredDeathmatchLeaderboard: [],
-      objectiveLeaderboard: [],
-      filteredObjectiveLeaderboard: [],
-      eliminationLeaderboard: [],
-      filteredEliminationLeaderboard: [],
-      activeTab: 'leaderboard',
-      language: 'de',
-      statuses: {
-        overview: { key: null, params: {}, isError: false },
-        leaderboard: { key: null, params: {}, isError: false },
-        deathmatch: { key: null, params: {}, isError: false },
-        elimination: { key: null, params: {}, isError: false },
-        ctf: { key: null, params: {}, isError: false }
-      }
 
-    };
+const state = {
+  allMatches: [],
+  leaderboard: [],
+  deathmatchLeaderboard: [],
+  objectiveLeaderboard: [],
+  eliminationLeaderboard: [],
+  modeData: new Map(),
+  selectedMaps: new Map(),
+      activeMode: MODE_CONFIG.length ? MODE_CONFIG[0].key : 'gt_racing',
+  language: 'de',
+  modeStatus: { key: null, params: {}, isError: false }
+};
 
-    const elements = {
-      modeFilter: document.getElementById('modeFilter'),
-      searchInput: document.getElementById('searchInput'),
-      limitSelect: document.getElementById('limitSelect'),
-      refreshButton: document.getElementById('refreshButton'),
-      statusMessage: document.getElementById('statusMessage'),
-      matches: document.getElementById('matches'),
-      statTotal: document.getElementById('stat-total'),
-      statLast: document.getElementById('stat-last'),
-      statModes: document.getElementById('stat-modes'),
-      statPlayers: document.getElementById('stat-players'),
+const elements = {
+  modeTabs: document.getElementById('modeTabs'),
+  modePanels: document.getElementById('modePanels'),
+  modeStatus: document.getElementById('modeStatus'),
+  statTotal: document.getElementById('stat-total'),
+  statLast: document.getElementById('stat-last'),
+  statModes: document.getElementById('stat-modes'),
+  statPlayers: document.getElementById('stat-players'),
+  modeBreakdown: document.getElementById('modeBreakdown'),
+  languageButtons: Array.from(document.querySelectorAll('.language-button')),
+  html: document.documentElement,
+  metaDescription: document.querySelector('meta[name="description"]')
+};
 
-      modeBreakdown: document.getElementById('modeBreakdown'),
-      leaderboardStatus: document.getElementById('leaderboardStatus'),
-      leaderboardBody: document.getElementById('leaderboardBody'),
-      leaderboardEmpty: document.getElementById('leaderboardEmpty'),
-      leaderboardModeFilter: document.getElementById('leaderboardModeFilter'),
-      leaderboardMapFilter: document.getElementById('leaderboardMapFilter'),
-      leaderboardPlayerSearch: document.getElementById('leaderboardPlayerSearch'),
-      deathmatchStatus: document.getElementById('deathmatchStatus'),
-      deathmatchBody: document.getElementById('deathmatchBody'),
-      deathmatchEmpty: document.getElementById('deathmatchEmpty'),
-      deathmatchModeFilter: document.getElementById('deathmatchModeFilter'),
-      deathmatchMapFilter: document.getElementById('deathmatchMapFilter'),
-      deathmatchPlayerSearch: document.getElementById('deathmatchPlayerSearch'),
-      eliminationStatus: document.getElementById('eliminationStatus'),
-      eliminationBody: document.getElementById('eliminationBody'),
-      eliminationEmpty: document.getElementById('eliminationEmpty'),
-      eliminationModeFilter: document.getElementById('eliminationModeFilter'),
-      eliminationMapFilter: document.getElementById('eliminationMapFilter'),
-      eliminationPlayerSearch: document.getElementById('eliminationPlayerSearch'),
-      ctfStatus: document.getElementById('ctfStatus'),
-      ctfBody: document.getElementById('ctfBody'),
-      ctfEmpty: document.getElementById('ctfEmpty'),
-      ctfModeFilter: document.getElementById('ctfModeFilter'),
-      ctfMapFilter: document.getElementById('ctfMapFilter'),
-      ctfPlayerSearch: document.getElementById('ctfPlayerSearch'),
-      tabButtons: Array.from(document.querySelectorAll('[data-tab]')),
-      tabPanels: {
-        leaderboard: document.getElementById('tab-leaderboard'),
-        deathmatch: document.getElementById('tab-deathmatch'),
-        elimination: document.getElementById('tab-elimination'),
-        ctf: document.getElementById('tab-ctf'),
-        matches: document.getElementById('tab-matches')
+const modeElements = new Map();
+const MODE_CONFIG_MAP = new Map(MODE_CONFIG.map((config) => [config.key, config]));
 
-      },
-      languageButtons: Array.from(document.querySelectorAll('.language-button')),
-      html: document.documentElement,
-      metaDescription: document.querySelector('meta[name="description"]')
-    };
+const TIME_PATH_CANDIDATES = [
+  'bestLap',
+  'bestLapTime',
+  'bestLapMs',
+  'bestLapMilliseconds',
+  'fastestLap',
+  'fastestLapTime',
+  'fastestLapMs',
+  'fastestLapMilliseconds',
+  'fastestTime',
+  'bestTime',
+  'raceTime',
+  'totalTime',
+  'total_time',
+  'lapTime',
+  'lap_time',
+  'duration',
+  'durationSeconds',
+  'duration_seconds',
+  'stats.bestLap',
+  'stats.bestLapTime',
+  'stats.fastestLap',
+  'stats.fastestTime',
+  'stats.raceTime',
+  'result.bestLap',
+  'result.bestLapTime',
+  'result.fastestLap',
+  'result.fastestTime',
+  'timing.bestLap',
+  'timing.bestTime',
+  'timing.totalTime',
+  'timings.bestLap',
+  'timings.bestTime'
+];
 
-    function getLocale(lang = state.language) {
-      return lang === 'de' ? 'de-DE' : 'en-US';
+const PLAYER_PATH_CANDIDATES = [
+  'name',
+  'nick',
+  'nickname',
+  'player',
+  'playerName',
+  'driver',
+  'driverName',
+  'racer',
+  'pilot',
+  'id',
+  'uid',
+  'guid',
+  'stats.name',
+  'stats.player',
+  'result.name',
+  'result.player'
+];
+
+const VEHICLE_PATH_CANDIDATES = [
+  'vehicle',
+  'car',
+  'bike',
+  'kart',
+  'ride',
+  'stats.vehicle',
+  'result.vehicle'
+];
+
+const SCOREBOARD_PATHS = [
+  'leaderboard',
+  'leaderboard.entries',
+  'results',
+  'results.entries',
+  'scoreboard',
+  'scores',
+  'stats.results',
+  'match.scoreboard',
+  'match.results',
+  'timing.results',
+  'timing.leaderboard',
+  'timings',
+  'players'
+];
+
+const MAX_REASONABLE_TIME = 6 * 3600;
+
+const KILL_PATH_CANDIDATES = [
+  'kills',
+  'frags',
+  'stats.kills',
+  'stats.frags',
+  'result.kills',
+  'result.frags',
+  'summary.kills',
+  'summary.frags',
+  'totals.kills',
+  'totals.frags'
+];
+
+const DEATH_PATH_CANDIDATES = [
+  'deaths',
+  'death',
+  'stats.deaths',
+  'stats.death',
+  'result.deaths',
+  'summary.deaths',
+  'totals.deaths'
+];
+
+function getLocale(lang = state.language) {
+  return lang === 'de' ? 'de-DE' : 'en-US';
+}
+
+function createFormatter(lang = state.language) {
+  return new Intl.DateTimeFormat(getLocale(lang), {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+}
+
+let formatter = createFormatter();
+
+function translateWithFallback(key, lang = state.language) {
+  const primary = I18N[lang] || {};
+  if (Object.prototype.hasOwnProperty.call(primary, key)) {
+    return primary[key];
+  }
+  if (lang !== 'en' && I18N.en && Object.prototype.hasOwnProperty.call(I18N.en, key)) {
+    return I18N.en[key];
+  }
+  if (lang !== 'de' && I18N.de && Object.prototype.hasOwnProperty.call(I18N.de, key)) {
+    return I18N.de[key];
+  }
+  return key;
+}
+
+function t(key, params = {}) {
+  const template = translateWithFallback(key);
+  if (typeof template !== 'string') {
+    return key;
+  }
+  return template.replace(/\{(\w+)\}/g, (match, token) => {
+    if (Object.prototype.hasOwnProperty.call(params, token)) {
+      return String(params[token]);
     }
+    return match;
+  });
+}
 
-    function createFormatter(lang = state.language) {
-      return new Intl.DateTimeFormat(getLocale(lang), {
-        dateStyle: 'medium',
-        timeStyle: 'short'
-      });
+function applyStaticTranslations() {
+  document.querySelectorAll('[data-i18n]').forEach((element) => {
+    const key = element.dataset.i18n;
+    if (key) {
+      element.textContent = t(key);
     }
-
-    let formatter = createFormatter();
-
-    function translateWithFallback(key, lang = state.language) {
-      const primary = I18N[lang] || {};
-      if (Object.prototype.hasOwnProperty.call(primary, key)) {
-        return primary[key];
-      }
-      if (lang !== 'en' && I18N.en && Object.prototype.hasOwnProperty.call(I18N.en, key)) {
-        return I18N.en[key];
-      }
-      if (lang !== 'de' && I18N.de && Object.prototype.hasOwnProperty.call(I18N.de, key)) {
-        return I18N.de[key];
-      }
-      return key;
+  });
+  document.querySelectorAll('[data-i18n-html]').forEach((element) => {
+    const key = element.dataset.i18nHtml;
+    if (key) {
+      element.innerHTML = t(key);
     }
-
-    function t(key, params = {}) {
-      const template = translateWithFallback(key);
-      if (typeof template !== 'string') {
-        return key;
-      }
-      return template.replace(/\{(\w+)\}/g, (match, token) => {
-        if (Object.prototype.hasOwnProperty.call(params, token)) {
-          return String(params[token]);
-        }
-        return match;
-      });
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach((element) => {
+    const key = element.dataset.i18nPlaceholder;
+    if (key) {
+      element.setAttribute('placeholder', t(key));
     }
-
-    function applyStaticTranslations() {
-      document.querySelectorAll('[data-i18n]').forEach((element) => {
-        const key = element.dataset.i18n;
-        if (key) {
-          element.textContent = t(key);
-        }
-      });
-      document.querySelectorAll('[data-i18n-html]').forEach((element) => {
-        const key = element.dataset.i18nHtml;
-        if (key) {
-          element.innerHTML = t(key);
-        }
-      });
-      document.querySelectorAll('[data-i18n-placeholder]').forEach((element) => {
-        const key = element.dataset.i18nPlaceholder;
-        if (key) {
-          element.setAttribute('placeholder', t(key));
-        }
-      });
-      document.querySelectorAll('[data-i18n-title]').forEach((element) => {
-        const key = element.dataset.i18nTitle;
-        if (key) {
-          element.setAttribute('title', t(key));
-        }
-      });
-      document.querySelectorAll('[data-i18n-aria-label]').forEach((element) => {
-        const key = element.dataset.i18nAriaLabel;
-        if (key) {
-          element.setAttribute('aria-label', t(key));
-        }
-      });
+  });
+  document.querySelectorAll('[data-i18n-title]').forEach((element) => {
+    const key = element.dataset.i18nTitle;
+    if (key) {
+      element.setAttribute('title', t(key));
     }
-
-    function updateLanguageButtons() {
-      elements.languageButtons.forEach((button) => {
-        const isActive = button.dataset.lang === state.language;
-        button.classList.toggle('active', isActive);
-        button.setAttribute('aria-pressed', String(isActive));
-      });
+  });
+  document.querySelectorAll('[data-i18n-aria-label]').forEach((element) => {
+    const key = element.dataset.i18nAriaLabel;
+    if (key) {
+      element.setAttribute('aria-label', t(key));
     }
+  });
+}
 
-    function formatMessage(key, params = {}) {
-      return t(key, params);
+function updateLanguageButtons() {
+  elements.languageButtons.forEach((button) => {
+    const isActive = button.dataset.lang === state.language;
+    button.classList.toggle('active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+}
+
+function setModeStatus(key, params = {}, isError = false, persist = true) {
+  const message = t(key, params);
+  elements.modeStatus.textContent = message;
+  elements.modeStatus.classList.toggle('error', Boolean(isError));
+  if (persist) {
+    state.modeStatus = { key, params, isError };
+  }
+}
+
+function applyLanguage(lang) {
+  if (!I18N[lang]) {
+    lang = 'de';
+  }
+  state.language = lang;
+  elements.html.lang = lang === 'de' ? 'de' : 'en';
+  formatter = createFormatter(lang);
+  document.title = t('meta.title');
+  if (elements.metaDescription) {
+    elements.metaDescription.setAttribute('content', t('meta.description'));
+  }
+  applyStaticTranslations();
+  updateLanguageButtons();
+  updateModeTabsLanguage();
+  updateSummary();
+  updateModeOptions();
+  MODE_CONFIG.forEach(({ key }) => {
+    renderModeTable(key);
+  });
+  if (state.modeStatus.key) {
+    setModeStatus(state.modeStatus.key, state.modeStatus.params, state.modeStatus.isError, false);
+  }
+}
+
+function createModeTabs() {
+  const tabFragment = document.createDocumentFragment();
+  const panelFragment = document.createDocumentFragment();
+  MODE_CONFIG.forEach((config, index) => {
+    const button = document.createElement('button');
+    button.className = 'tab-button';
+    button.type = 'button';
+    button.dataset.mode = config.key;
+    button.id = `mode-tab-${config.key}`;
+    button.setAttribute('role', 'tab');
+    button.setAttribute('aria-controls', `mode-panel-${config.key}`);
+    button.setAttribute('aria-selected', index === 0 ? 'true' : 'false');
+    button.setAttribute('tabindex', index === 0 ? '0' : '-1');
+    button.addEventListener('click', () => {
+      setActiveMode(config.key);
+    });
+    tabFragment.appendChild(button);
+
+    const panel = document.createElement('div');
+    panel.className = 'mode-panel tab-panel';
+    if (index === 0) {
+      panel.classList.add('active');
     }
+    panel.id = `mode-panel-${config.key}`;
+    panel.setAttribute('role', 'tabpanel');
+    panel.setAttribute('aria-labelledby', button.id);
 
-    function syncStatuses() {
-      if (state.statuses.overview.key) {
-        setStatus(state.statuses.overview.key, state.statuses.overview.params, state.statuses.overview.isError, false);
-      }
-      if (state.statuses.leaderboard.key) {
-        setLeaderboardStatus(state.statuses.leaderboard.key, state.statuses.leaderboard.params, state.statuses.leaderboard.isError, false);
-      }
-      if (state.statuses.deathmatch.key) {
-        setDeathmatchStatus(state.statuses.deathmatch.key, state.statuses.deathmatch.params, state.statuses.deathmatch.isError, false);
-      }
-      if (state.statuses.elimination.key) {
-        setEliminationStatus(state.statuses.elimination.key, state.statuses.elimination.params, state.statuses.elimination.isError, false);
-      }
-      if (state.statuses.ctf.key) {
-        setObjectiveStatus(state.statuses.ctf.key, state.statuses.ctf.params, state.statuses.ctf.isError, false);
-      }
-    }
+    const controls = document.createElement('div');
+    controls.className = 'mode-controls';
+    const mapWrapper = document.createElement('div');
+    const mapLabel = document.createElement('label');
+    mapLabel.setAttribute('for', `mode-map-${config.key}`);
+    mapLabel.dataset.i18n = 'mode.controls.map';
+    mapWrapper.appendChild(mapLabel);
+    const mapSelect = document.createElement('select');
+    mapSelect.id = `mode-map-${config.key}`;
+    mapSelect.disabled = true;
+    mapSelect.addEventListener('change', () => {
+      state.selectedMaps.set(config.key, mapSelect.value);
+      renderModeTable(config.key);
+    });
+    mapWrapper.appendChild(mapSelect);
+    controls.appendChild(mapWrapper);
+    panel.appendChild(controls);
 
-    function applyLanguage(lang) {
-      if (!I18N[lang]) {
-        lang = 'de';
-      }
-      state.language = lang;
-      elements.html.lang = lang === 'de' ? 'de' : 'en';
-      formatter = createFormatter(lang);
-      document.title = t('meta.title');
-      if (elements.metaDescription) {
-        elements.metaDescription.setAttribute('content', t('meta.description'));
-      }
-      applyStaticTranslations();
-      updateLanguageButtons();
-      updateModeFilter();
-      updateSummary();
-      buildLeaderboard();
-      updateLeaderboardFilters();
-      if (state.leaderboard.length) {
-        applyLeaderboardFilters();
-      } else {
-        elements.leaderboardBody.innerHTML = '';
-        elements.leaderboardEmpty.hidden = true;
-      }
-      buildDeathmatchLeaderboard();
-      updateDeathmatchFilters();
-      if (state.deathmatchLeaderboard.length) {
-        applyDeathmatchFilters();
-      } else {
-        elements.deathmatchBody.innerHTML = '';
-        elements.deathmatchEmpty.hidden = true;
-      }
-      buildObjectiveLeaderboard();
-      updateEliminationFilters();
-      updateObjectiveFilters();
-      if (state.eliminationLeaderboard.length) {
-        applyEliminationFilters();
-      } else {
-        elements.eliminationBody.innerHTML = '';
-        elements.eliminationEmpty.hidden = true;
-      }
-      if (state.objectiveLeaderboard.length) {
-        applyObjectiveFilters();
-      } else {
-        elements.ctfBody.innerHTML = '';
-        elements.ctfEmpty.hidden = true;
-      }
-      if (state.allMatches.length) {
-        applyFilters();
-      } else {
-        elements.matches.innerHTML = '';
-      }
-      syncStatuses();
-    }
+    const layout = document.createElement('div');
+    layout.className = 'mode-layout';
 
+    const figure = document.createElement('figure');
+    figure.className = 'mode-levelshot';
+    const shot = document.createElement('img');
+    shot.alt = '';
+    shot.loading = 'lazy';
+    shot.decoding = 'async';
+    const fallback = document.createElement('p');
+    fallback.className = 'mode-levelshot-fallback';
+    fallback.dataset.i18n = 'mode.levelshot.missing';
+    fallback.hidden = true;
+    shot.addEventListener('error', () => {
+      shot.hidden = true;
+      fallback.hidden = false;
+    });
+    shot.addEventListener('load', () => {
+      shot.hidden = false;
+      fallback.hidden = true;
+    });
+    const caption = document.createElement('figcaption');
+    figure.appendChild(shot);
+    figure.appendChild(fallback);
+    figure.appendChild(caption);
+    layout.appendChild(figure);
 
-    const TIME_PATH_CANDIDATES = [
-      'bestLap',
-      'bestLapTime',
-      'bestLapMs',
-      'bestLapMilliseconds',
-      'fastestLap',
-      'fastestLapTime',
-      'fastestLapMs',
-      'fastestLapMilliseconds',
-      'fastestTime',
-      'bestTime',
-      'raceTime',
-      'totalTime',
-      'total_time',
-      'lapTime',
-      'lap_time',
-      'duration',
-      'durationSeconds',
-      'duration_seconds',
-      'stats.bestLap',
-      'stats.bestLapTime',
-      'stats.fastestLap',
-      'stats.fastestTime',
-      'stats.raceTime',
-      'result.bestLap',
-      'result.bestLapTime',
-      'result.fastestLap',
-      'result.fastestTime',
-      'timing.bestLap',
-      'timing.bestTime',
-      'timing.totalTime',
-      'timings.bestLap',
-      'timings.bestTime'
+    const tableWrapper = document.createElement('div');
+    tableWrapper.className = 'mode-table-wrapper';
+    const heading = document.createElement('h3');
+    heading.dataset.i18n = 'mode.table.heading';
+    tableWrapper.appendChild(heading);
+    const tableContainer = document.createElement('div');
+    tableContainer.className = 'table-wrapper';
+    const table = document.createElement('table');
+    table.className = 'leaderboard-table';
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    table.appendChild(tbody);
+    tableContainer.appendChild(table);
+    tableWrapper.appendChild(tableContainer);
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.dataset.i18n = 'mode.empty';
+    empty.hidden = true;
+    tableWrapper.appendChild(empty);
+    layout.appendChild(tableWrapper);
+
+    panel.appendChild(layout);
+    panelFragment.appendChild(panel);
+
+    modeElements.set(config.key, {
+      button,
+      panel,
+      mapSelect,
+      table,
+      tableHeadRow: headerRow,
+      tableBody: tbody,
+      tableContainer,
+      empty,
+      levelshot: shot,
+      levelshotFallback: fallback,
+      levelshotCaption: caption,
+      tableHeading: heading
+    });
+  });
+
+  elements.modeTabs.innerHTML = '';
+  elements.modeTabs.appendChild(tabFragment);
+  elements.modePanels.innerHTML = '';
+  elements.modePanels.appendChild(panelFragment);
+
+  const buttons = Array.from(elements.modeTabs.querySelectorAll('.tab-button'));
+  buttons.forEach((button, index) => {
+    button.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+        event.preventDefault();
+        const direction = event.key === 'ArrowRight' ? 1 : -1;
+        const nextIndex = (index + direction + buttons.length) % buttons.length;
+        const nextButton = buttons[nextIndex];
+        nextButton.focus();
+        setActiveMode(nextButton.dataset.mode);
+      }
+    });
+  });
+}
+
+function setActiveMode(modeKey) {
+  if (!modeElements.has(modeKey)) {
+    return;
+  }
+  state.activeMode = modeKey;
+  modeElements.forEach((refs, key) => {
+    const isActive = key === modeKey;
+    refs.button.classList.toggle('active', isActive);
+    refs.button.setAttribute('aria-selected', String(isActive));
+    refs.button.setAttribute('tabindex', isActive ? '0' : '-1');
+    refs.panel.classList.toggle('active', isActive);
+  });
+  renderModeTable(modeKey);
+}
+
+function updateModeTabsLanguage() {
+  modeElements.forEach((refs, key) => {
+    refs.button.textContent = humanizeMode(key);
+  });
+}
+
+function getColumnsForMode(config) {
+  if (config.type === 'race') {
+    return [
+      { key: 'rank', labelKey: 'leaderboard.headers.rank' },
+      { key: 'player', labelKey: 'leaderboard.headers.player' },
+      { key: 'time', labelKey: 'leaderboard.headers.time' },
+      { key: 'vehicle', labelKey: 'leaderboard.headers.vehicle' },
+      { key: 'recorded', labelKey: 'leaderboard.headers.recorded' }
     ];
-
-    const PLAYER_PATH_CANDIDATES = [
-      'name',
-      'nick',
-      'nickname',
-      'player',
-      'playerName',
-      'driver',
-      'driverName',
-      'racer',
-      'pilot',
-      'id',
-      'uid',
-      'guid',
-      'stats.name',
-      'stats.player',
-      'result.name',
-      'result.player'
+  }
+  if (config.type === 'deathmatch') {
+    return [
+      { key: 'rank', labelKey: 'deathmatch.headers.rank' },
+      { key: 'player', labelKey: 'deathmatch.headers.player' },
+      { key: 'kdr', labelKey: 'deathmatch.headers.kdr' },
+      { key: 'kills', labelKey: 'deathmatch.headers.kills' },
+      { key: 'deaths', labelKey: 'deathmatch.headers.deaths' },
+      { key: 'recorded', labelKey: 'deathmatch.headers.recorded' }
     ];
+  }
+  return [
+    { key: 'rank', labelKey: 'leaderboard.headers.rank' },
+    { key: 'player', labelKey: 'leaderboard.headers.player' },
+    { key: 'metric', labelKey: 'mode.headers.metric' },
+    { key: 'value', labelKey: 'ctf.headers.value' },
+    { key: 'recorded', labelKey: 'ctf.headers.recorded' }
+  ];
+}
 
-    const VEHICLE_PATH_CANDIDATES = [
-      'vehicle',
-      'car',
-      'bike',
-      'kart',
-      'ride',
-      'stats.vehicle',
-      'result.vehicle'
-    ];
+function updateModeOptions() {
+  MODE_CONFIG.forEach(({ key }) => updateModeOptionsForMode(key));
+}
 
-    const SCOREBOARD_PATHS = [
-      'leaderboard',
-      'leaderboard.entries',
-      'results',
-      'results.entries',
-      'scoreboard',
-      'scores',
-      'stats.results',
-      'match.scoreboard',
-      'match.results',
-      'timing.results',
-      'timing.leaderboard',
-      'timings',
-      'players'
-    ];
+function updateModeOptionsForMode(modeKey) {
+  const refs = modeElements.get(modeKey);
+  if (!refs) {
+    return;
+  }
+  const modeMap = state.modeData.get(modeKey);
+  const previous = state.selectedMaps.get(modeKey);
+  refs.mapSelect.innerHTML = '';
+  if (!modeMap || modeMap.size === 0) {
+    refs.mapSelect.disabled = true;
+    state.selectedMaps.delete(modeKey);
+    return;
+  }
+  const locale = getLocale();
+  const options = Array.from(modeMap.values())
+    .map((entry) => ({
+      value: entry.mapKey,
+      label: humanizeMapName(entry.map)
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label, locale));
+  options.forEach(({ value, label }) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    refs.mapSelect.appendChild(option);
+  });
+  refs.mapSelect.disabled = false;
+  if (previous && modeMap.has(previous)) {
+    refs.mapSelect.value = previous;
+  } else {
+    refs.mapSelect.value = options[0].value;
+    state.selectedMaps.set(modeKey, options[0].value);
+  }
+}
 
-    const MAX_REASONABLE_TIME = 6 * 3600; // 6 Stunden
-
-    const KILL_PATH_CANDIDATES = [
-      'kills',
-      'frags',
-      'stats.kills',
-      'stats.frags',
-      'result.kills',
-      'result.frags',
-      'summary.kills',
-      'summary.frags',
-      'totals.kills',
-      'totals.frags'
-    ];
-
-    const DEATH_PATH_CANDIDATES = [
-      'deaths',
-      'death',
-      'stats.deaths',
-      'stats.death',
-      'result.deaths',
-      'summary.deaths',
-      'totals.deaths'
-    ];
-
-
-    function setStatus(key, params = {}, isError = false, persist = true) {
-      const message = formatMessage(key, params);
-      elements.statusMessage.textContent = message;
-      elements.statusMessage.classList.toggle('error', Boolean(isError));
-      if (persist) {
-        state.statuses.overview = { key, params, isError };
-      }
+function renderModeTable(modeKey) {
+  const refs = modeElements.get(modeKey);
+  if (!refs) {
+    return;
+  }
+  const config = MODE_CONFIG_MAP.get(modeKey);
+  const modeMap = state.modeData.get(modeKey) || new Map();
+  if (!state.selectedMaps.has(modeKey) && modeMap.size) {
+    const firstKey = modeMap.keys().next().value;
+    state.selectedMaps.set(modeKey, firstKey);
+    if (refs.mapSelect && !refs.mapSelect.value) {
+      refs.mapSelect.value = firstKey;
     }
+  }
+  const selectedMap = state.selectedMaps.get(modeKey);
+  if (refs.mapSelect && selectedMap && refs.mapSelect.value !== selectedMap) {
+    refs.mapSelect.value = selectedMap;
+  }
 
-    function setLeaderboardStatus(key, params = {}, isError = false, persist = true) {
-      const message = formatMessage(key, params);
-      elements.leaderboardStatus.textContent = message;
-      elements.leaderboardStatus.classList.toggle('error', Boolean(isError));
-      if (persist) {
-        state.statuses.leaderboard = { key, params, isError };
-      }
+  const columns = getColumnsForMode(config);
+  refs.tableHeadRow.innerHTML = '';
+  columns.forEach((column) => {
+    const th = document.createElement('th');
+    th.scope = 'col';
+    th.dataset.i18n = column.labelKey;
+    th.textContent = t(column.labelKey);
+    refs.tableHeadRow.appendChild(th);
+  });
 
-    }
+  if (!selectedMap || !modeMap.has(selectedMap)) {
+    refs.tableBody.innerHTML = '';
+    refs.tableContainer.hidden = true;
+    refs.empty.hidden = false;
+    updateLevelshot(modeKey, null);
+    return;
+  }
 
-    function setDeathmatchStatus(key, params = {}, isError = false, persist = true) {
-      const message = formatMessage(key, params);
-      elements.deathmatchStatus.textContent = message;
-      elements.deathmatchStatus.classList.toggle('error', Boolean(isError));
-      if (persist) {
-        state.statuses.deathmatch = { key, params, isError };
-      }
+  const mapData = modeMap.get(selectedMap);
+  updateLevelshot(modeKey, mapData);
 
-    }
+  const rows = mapData.entries.slice(0, 10);
+  refs.tableBody.innerHTML = '';
+  if (!rows.length) {
+    refs.tableContainer.hidden = true;
+    refs.empty.hidden = false;
+    return;
+  }
 
-    function setEliminationStatus(key, params = {}, isError = false, persist = true) {
-      const message = formatMessage(key, params);
-      elements.eliminationStatus.textContent = message;
-      elements.eliminationStatus.classList.toggle('error', Boolean(isError));
-      if (persist) {
-        state.statuses.elimination = { key, params, isError };
-      }
+  refs.tableContainer.hidden = false;
+  refs.empty.hidden = true;
 
-    }
-
-    function setObjectiveStatus(key, params = {}, isError = false, persist = true) {
-      const message = formatMessage(key, params);
-      elements.ctfStatus.textContent = message;
-      elements.ctfStatus.classList.toggle('error', Boolean(isError));
-      if (persist) {
-        state.statuses.ctf = { key, params, isError };
-      }
-
-    }
-
-    function valueAtPath(obj, path) {
-      const parts = path.split('.');
-      let current = obj;
-      for (const part of parts) {
-        if (current && Object.prototype.hasOwnProperty.call(current, part)) {
-          current = current[part];
-        } else {
-          return undefined;
+  rows.forEach((entry, index) => {
+    const tr = document.createElement('tr');
+    columns.forEach((column) => {
+      const td = document.createElement('td');
+      switch (column.key) {
+        case 'rank':
+          td.textContent = String(index + 1);
+          break;
+        case 'player': {
+          const strong = document.createElement('strong');
+          strong.textContent = entry.player || t('common.unknown');
+          td.appendChild(strong);
+          break;
         }
-      }
-      return current;
-    }
-
-    function firstString(obj, paths) {
-      for (const path of paths) {
-        const value = valueAtPath(obj, path);
-        if (typeof value === 'string' && value.trim() !== '') {
-          return value.trim();
+        case 'time':
+          td.textContent = formatRaceTime(entry.time);
+          break;
+        case 'vehicle':
+          td.textContent = entry.vehicle ? entry.vehicle : '–';
+          break;
+        case 'kdr':
+          td.textContent = formatRatio(entry.ratio);
+          break;
+        case 'kills':
+          td.textContent = entry.kills != null ? String(entry.kills) : '–';
+          break;
+        case 'deaths':
+          td.textContent = entry.deaths != null ? String(entry.deaths) : '–';
+          break;
+        case 'metric': {
+          const labelKey = OBJECTIVE_METRIC_LABEL_KEYS[entry.metricType] || OBJECTIVE_METRIC_LABEL_KEYS.value;
+          td.textContent = t(labelKey);
+          break;
         }
+        case 'value':
+          td.textContent = entry.value != null ? String(entry.value) : '–';
+          break;
+        case 'recorded':
+          td.textContent = formatDate(entry.recordedAt || entry.startedAt);
+          break;
+        default:
+          td.textContent = '';
       }
-      return '';
-    }
+      tr.appendChild(td);
+    });
+    refs.tableBody.appendChild(tr);
+  });
+}
 
-    function firstNumber(obj, paths) {
-      for (const path of paths) {
-        const value = valueAtPath(obj, path);
-        if (typeof value === 'number' && Number.isFinite(value)) {
-          return value;
-        }
-        if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) {
-          return Number(value);
-        }
-      }
-      return null;
-    }
+function updateLevelshot(modeKey, mapData) {
+  const refs = modeElements.get(modeKey);
+  if (!refs) {
+    return;
+  }
+      const mapName = mapData ? mapData.map : '';
+      const humanized = mapName ? humanizeMapName(mapName) : '';
+      refs.levelshotCaption.textContent = humanized;
+      refs.levelshot.alt = humanized || '';
+  if (!mapData) {
+    refs.levelshot.hidden = true;
+    refs.levelshotFallback.hidden = false;
+    refs.levelshot.removeAttribute('src');
+    return;
+  }
+  const path = getLevelshotPath(mapData.map);
+  if (!path) {
+    refs.levelshot.hidden = true;
+    refs.levelshotFallback.hidden = false;
+    refs.levelshot.removeAttribute('src');
+    return;
+  }
+  if (refs.levelshot.src !== path) {
+    refs.levelshot.src = path;
+  }
+}
 
-    function pickArray(obj, paths) {
-      for (const path of paths) {
-        const value = valueAtPath(obj, path);
-        if (Array.isArray(value)) {
-          return value;
-        }
-      }
-      return [];
-    }
+function formatRaceTime(seconds) {
+  if (seconds === null || seconds === undefined) {
+    return '–';
+  }
+  return formatSeconds(seconds);
+}
 
-    function parseNumericValue(value) {
-      if (typeof value === 'number' && Number.isFinite(value)) {
-        return value;
-      }
-      if (typeof value === 'string') {
-        const normalized = value.trim().replace(',', '.');
-        if (normalized === '') {
-          return null;
-        }
-        const numeric = Number(normalized);
-        return Number.isFinite(numeric) ? numeric : null;
-      }
-      return null;
-    }
+function formatRatio(value) {
+  if (!Number.isFinite(value)) {
+    return '–';
+  }
+  if (value >= 10) {
+    return value.toFixed(1);
+  }
+  return value.toFixed(2);
+}
 
-    function numericAtPaths(obj, paths) {
-      for (const path of paths) {
-        const value = valueAtPath(obj, path);
-        const numeric = parseNumericValue(value);
-        if (numeric !== null) {
-          return numeric;
-        }
-      }
-      return null;
-    }
+function formatDate(value) {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    return '–';
+  }
+  return formatter.format(value);
+}
 
-    function searchNumericByKeywords(node, keywords, visited = new Set()) {
-      if (node === null || node === undefined) {
-        return null;
-      }
-      if (typeof node !== 'object') {
-        return null;
-      }
-      if (visited.has(node)) {
-        return null;
-      }
-      visited.add(node);
-      if (Array.isArray(node)) {
-        for (const item of node) {
-          const result = searchNumericByKeywords(item, keywords, visited);
-          if (result !== null) {
-            return result;
-          }
-        }
-        return null;
-      }
-      for (const [key, value] of Object.entries(node)) {
-        const lowerKey = key.toLowerCase();
-        if (keywords.some((keyword) => lowerKey.includes(keyword))) {
-          const numeric = parseNumericValue(value);
-          if (numeric !== null) {
-            return numeric;
-          }
-        }
-        if (value && typeof value === 'object') {
-          const nested = searchNumericByKeywords(value, keywords, visited);
-          if (nested !== null) {
-            return nested;
-          }
-        }
-      }
-      return null;
-    }
-
-    function parseDate(value) {
-      if (value === null || value === undefined) {
-        return null;
-      }
-      if (value instanceof Date) {
-        return Number.isNaN(value.getTime()) ? null : value;
-      }
-      if (typeof value === 'number') {
-        const ms = value > 1e12 ? value : value * 1000;
-        const date = new Date(ms);
-        return Number.isNaN(date.getTime()) ? null : date;
-      }
-      if (typeof value === 'string') {
-        const trimmed = value.trim();
-        if (trimmed === '') {
-          return null;
-        }
-        const numeric = Number(trimmed);
-        if (!Number.isNaN(numeric)) {
-          return parseDate(numeric);
-        }
-        const date = new Date(trimmed);
-        return Number.isNaN(date.getTime()) ? null : date;
-      }
-      return null;
-    }
-
-    function extractMode(match) {
-      return firstString(match, [
-        'mode',
-        'matchMode',
-        'match.mode',
-        'gameType',
-        'game_type',
-        'gametype',
-        'info.mode',
-        'settings.mode',
-        'rules.mode',
-        'meta.mode',
-        'type'
-
-      ]) || '__unknown__';
-
-    }
-
-    function extractMap(match) {
-      return firstString(match, [
-        'map',
-        'mapName',
-        'match.map',
-        'metadata.map',
-        'level',
-        'settings.map',
-        'info.map'
-      ]) || '–';
-    }
-
-    function extractDuration(match) {
-      const seconds = firstNumber(match, [
-        'duration',
-        'match.duration',
-        'length',
-        'matchLength',
-        'timing.durationSeconds'
-      ]);
-      if (seconds === null) {
+    function getLevelshotPath(mapName) {
+      if (typeof mapName !== 'string') {
         return '';
       }
-      const totalSeconds = Math.max(0, Math.round(seconds));
-      const minutes = Math.floor(totalSeconds / 60);
-      const secs = totalSeconds % 60;
-      if (minutes === 0) {
-        return `${totalSeconds}s`;
-      }
-      return `${minutes}m ${secs.toString().padStart(2, '0')}s`;
-    }
-
-    function extractStart(match) {
-      const candidate = firstString(match, [
-        'startTime',
-        'match.startTime',
-        'startedAt',
-        'match.startedAt',
-        'serverStartTime',
-        'start',
-        'matchStart',
-        'info.started',
-        'receivedAt'
-      ]);
-      const numeric = firstNumber(match, [
-        'startTimestamp',
-        'startedAtUnix',
-        'timestamps.start',
-        'match.startTimestamp'
-      ]);
-      return parseDate(candidate || numeric || match.receivedAt || null);
-    }
-
-    function extractMatchId(match) {
-
-      const id = firstString(match, [
-
-        'matchId',
-        'id',
-        'match.id',
-        'identifier',
-        'metadata.id'
-
-      ]);
-      return id || t('common.unknown');
-    }
-
-
-    function extractRecordedAtFromMatchId(matchId) {
-      if (typeof matchId !== 'string') {
-        return null;
-      }
-
-      const digits = matchId.replace(/\D+/g, '');
-      if (digits.length < 12) {
-        return null;
-      }
-
-      const year = Number(digits.slice(0, 4));
-      const month = Number(digits.slice(4, 6)) - 1;
-      const day = Number(digits.slice(6, 8));
-      const hour = Number(digits.slice(8, 10));
-      const minute = Number(digits.slice(10, 12));
-      const second = digits.length >= 14 ? Number(digits.slice(12, 14)) : 0;
-
-      if (
-        [year, month, day, hour, minute, second].some((part) => Number.isNaN(part)) ||
-        month < 0 || month > 11 ||
-        day < 1 || day > 31 ||
-        hour > 23 ||
-        minute > 59 ||
-        second > 59
-      ) {
-        return null;
-      }
-
-      const candidate = new Date(year, month, day, hour, minute, second);
-      return Number.isNaN(candidate.getTime()) ? null : candidate;
-    }
-
-    function extractPlayers(match) {
-      const candidates = pickArray(match, [
-        'players',
-        'participants',
-        'scores',
-        'scoreboard',
-        'stats.players',
-        'match.players'
-      ]);
-
-      const names = new Set();
-      for (const entry of candidates) {
-        if (typeof entry === 'string' && entry.trim() !== '') {
-          names.add(entry.trim());
-          continue;
-        }
-        if (entry && typeof entry === 'object') {
-          const name = firstString(entry, ['name', 'nick', 'nickname', 'player', 'id', 'uid']);
-          if (name) {
-            names.add(name);
-          }
-        }
-      }
-      return Array.from(names);
-    }
-
-    function escapeHtml(value) {
-      return value
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;')
-        .replaceAll("'", '&#039;');
-    }
-
-
-    function canonicalMode(mode) {
-      if (typeof mode !== 'string') {
-        return '__unknown__';
-      }
-
-      const trimmed = mode.trim();
-      if (!trimmed) {
-        return '__unknown__';
-      }
-      return trimmed.toLowerCase();
-
-    }
-
-    function humanizeMode(mode) {
-      if (typeof mode !== 'string') {
-
-        return t('mode.unknown');
-
-      }
-
-      const trimmed = mode.trim();
-      if (!trimmed) {
-
-        return t('mode.unknown');
-      }
-
-      const key = trimmed.toLowerCase();
-      const translations = MODE_TRANSLATIONS[state.language] || {};
-      if (Object.prototype.hasOwnProperty.call(translations, key)) {
-        return translations[key];
-
-      }
-
-      const withoutPrefix = trimmed.replace(/^GT[_\-\s]?/i, '');
-      const normalized = withoutPrefix.replace(/[_\-]+/g, ' ').toLowerCase();
-
-      const locale = getLocale();
-      return normalized.replace(/(^|\s)([\p{L}])/gu, (match, prefix, char) => prefix + char.toLocaleUpperCase(locale));
-
-    }
-
-    function isReasonableRaceTime(seconds) {
-      return Number.isFinite(seconds) && seconds > 0 && seconds < MAX_REASONABLE_TIME;
-    }
-
-    function parseTimeToSeconds(value) {
-      if (value === null || value === undefined) {
-        return null;
-      }
-
-      if (typeof value === 'number') {
-        const abs = Math.abs(value);
-        if (!Number.isFinite(abs) || abs === 0) {
-          return null;
-        }
-        if (abs < MAX_REASONABLE_TIME) {
-          return abs;
-        }
-        if (abs >= 600 && abs < MAX_REASONABLE_TIME * 1000) {
-          return abs / 1000;
-        }
-        if (abs >= 600 && abs < MAX_REASONABLE_TIME * 1_000_000) {
-          return abs / 1_000_000;
-        }
-        return null;
-      }
-
-      if (typeof value === 'string') {
-        const trimmed = value.trim();
-        if (trimmed === '') {
-          return null;
-        }
-
-        const normalized = trimmed.replace(',', '.');
-        const numeric = Number(normalized);
-        if (!Number.isNaN(numeric)) {
-          return parseTimeToSeconds(numeric);
-        }
-
-        const msMatch = normalized.match(/^([0-9]+(?:\.[0-9]+)?)\s*ms$/i);
-        if (msMatch) {
-          return parseFloat(msMatch[1]) / 1000;
-        }
-
-        const secMatch = normalized.match(/^([0-9]+(?:\.[0-9]+)?)\s*s$/i);
-        if (secMatch) {
-          return parseFloat(secMatch[1]);
-        }
-
-        const minuteMatch = normalized.match(/^([0-9]+)\s*m(?:in)?\s*([0-9]+(?:\.[0-9]+)?)\s*s$/i);
-        if (minuteMatch) {
-          return Number(minuteMatch[1]) * 60 + Number(minuteMatch[2]);
-        }
-
-        const isoMatch = normalized.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?$/i);
-        if (isoMatch) {
-          const hours = isoMatch[1] ? Number(isoMatch[1]) : 0;
-          const minutes = isoMatch[2] ? Number(isoMatch[2]) : 0;
-          const seconds = isoMatch[3] ? Number(isoMatch[3]) : 0;
-          return hours * 3600 + minutes * 60 + seconds;
-        }
-
-        const colonMatch = normalized.match(/^(\d+):(\d{2})(?::(\d{2}))?(?:\.(\d+))?$/);
-        if (colonMatch) {
-          const first = Number(colonMatch[1]);
-          const second = Number(colonMatch[2]);
-          const third = colonMatch[3] !== undefined ? Number(colonMatch[3]) : null;
-          const fraction = colonMatch[4] ? Number(`0.${colonMatch[4]}`) : 0;
-          if (third !== null) {
-            return first * 3600 + second * 60 + third + fraction;
-          }
-          return first * 60 + second + fraction;
-        }
-
-        const simpleMinuteMatch = normalized.match(/^([0-9]+)m(?:in)?$/i);
-        if (simpleMinuteMatch) {
-          return Number(simpleMinuteMatch[1]) * 60;
-        }
-
-        return null;
-      }
-
-      return null;
-    }
-
-    function findBestTime(entry) {
-      if (!entry || typeof entry !== 'object') {
-        return null;
-      }
-
-      let best = null;
-      for (const path of TIME_PATH_CANDIDATES) {
-        const candidate = valueAtPath(entry, path);
-        const seconds = parseTimeToSeconds(candidate);
-        if (seconds !== null && isReasonableRaceTime(seconds)) {
-          if (best === null || seconds < best) {
-            best = seconds;
-          }
-        }
-      }
-
-      if (best !== null) {
-        return best;
-      }
-
-      const visited = new Set();
-      function walk(node, hint = '') {
-        if (node === null || node === undefined) {
-          return;
-        }
-        if (typeof node === 'number' || typeof node === 'string') {
-          const keyHint = String(hint).toLowerCase();
-          if (keyHint.includes('time') || keyHint.includes('lap') || keyHint.includes('duration')) {
-            const seconds = parseTimeToSeconds(node);
-            if (seconds !== null && isReasonableRaceTime(seconds)) {
-              if (best === null || seconds < best) {
-                best = seconds;
-              }
-            }
-          }
-          return;
-        }
-        if (typeof node === 'object') {
-          if (visited.has(node)) {
-            return;
-          }
-          visited.add(node);
-          if (Array.isArray(node)) {
-            for (const item of node) {
-              walk(item, hint);
-            }
-            return;
-          }
-          for (const [key, value] of Object.entries(node)) {
-            walk(value, key);
-          }
-        }
-      }
-
-      walk(entry, '');
-      return best;
-    }
-
-    function extractLeaderboardPlayer(entry) {
-      if (entry === null || entry === undefined) {
+      const trimmed = mapName.trim();
+      if (!trimmed || trimmed === '–' || trimmed === '-') {
         return '';
       }
-      if (typeof entry === 'string') {
-        return entry.trim();
-      }
-      if (typeof entry !== 'object') {
+      const base = trimmed.replace(/\.[^./\\]+$/, '');
+      if (!base) {
         return '';
       }
-      const name = firstString(entry, PLAYER_PATH_CANDIDATES);
-      if (name) {
-        return name;
-      }
-      if (entry.stats && typeof entry.stats === 'object') {
-        return firstString(entry.stats, PLAYER_PATH_CANDIDATES);
-      }
-      if (entry.result && typeof entry.result === 'object') {
-        return firstString(entry.result, PLAYER_PATH_CANDIDATES);
-      }
-      return '';
+      return `images/${encodeURIComponent(base.toLowerCase())}.tga`;
     }
 
-    function extractVehicle(entry) {
-      if (!entry || typeof entry !== 'object') {
-        return '';
-      }
-      const vehicle = firstString(entry, VEHICLE_PATH_CANDIDATES);
-      if (vehicle) {
-        return vehicle;
-      }
-      if (entry.stats && typeof entry.stats === 'object') {
-        return firstString(entry.stats, VEHICLE_PATH_CANDIDATES);
-      }
-      if (entry.result && typeof entry.result === 'object') {
-        return firstString(entry.result, VEHICLE_PATH_CANDIDATES);
-      }
-      return '';
-    }
+function humanizeMapName(map) {
+  if (typeof map !== 'string') {
+    return t('map.unknown');
+  }
+  const trimmed = map.trim();
+  if (!trimmed) {
+    return t('map.unknown');
+  }
+  const base = trimmed.replace(/\.[^./\\]+$/, '');
+  const normalized = base.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').toLowerCase();
+  const locale = getLocale();
+  return normalized.replace(/(^|\s)([\p{L}])/gu, (match, prefix, char) => prefix + char.toLocaleUpperCase(locale));
+}
 
-    function formatSeconds(seconds) {
-      if (!Number.isFinite(seconds)) {
-        return '–';
-      }
-      const totalMilliseconds = Math.round(seconds * 1000);
-      const hours = Math.floor(totalMilliseconds / 3_600_000);
-      const minutes = Math.floor((totalMilliseconds % 3_600_000) / 60_000);
-      const secs = Math.floor((totalMilliseconds % 60_000) / 1000);
-      const millis = totalMilliseconds % 1000;
-      const millisStr = millis.toString().padStart(3, '0');
-      if (hours > 0) {
-        return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}.${millisStr}`;
-      }
-      return `${minutes}:${secs.toString().padStart(2, '0')}.${millisStr}`;
-    }
+function prepareModeData() {
+  const modeData = new Map();
+  MODE_CONFIG.forEach(({ key }) => {
+    modeData.set(key, new Map());
+  });
 
-    function formatRatio(value) {
-      if (!Number.isFinite(value)) {
-        return '–';
-      }
-      const precision = value >= 10 ? 2 : 3;
-      let fixed = value.toFixed(precision);
-      if (fixed.includes('.')) {
-        fixed = fixed.replace(/0+$/, '').replace(/\.$/, '');
-      }
-      return fixed;
+  function addEntry(modeKey, entry) {
+    const maps = modeData.get(modeKey);
+    if (!maps) {
+      return;
     }
-
-    function formatCount(value) {
-      if (!Number.isFinite(value)) {
-        return '–';
-      }
-      if (Number.isInteger(value)) {
-        return value.toString();
-      }
-      let fixed = value.toFixed(2);
-      if (fixed.includes('.')) {
-        fixed = fixed.replace(/0+$/, '').replace(/\.$/, '');
-      }
-      return fixed;
+    const mapKey = entry.mapKey || entry.map.toLowerCase();
+    if (!maps.has(mapKey)) {
+      maps.set(mapKey, { map: entry.map, mapKey, entries: [] });
     }
+    maps.get(mapKey).entries.push(entry);
+  }
 
-    function extractScoreboardEntries(match) {
-      const entries = [];
-      const seen = new Set();
-      for (const path of SCOREBOARD_PATHS) {
-        const value = valueAtPath(match, path);
-        if (!Array.isArray(value) || value.length === 0) {
-          continue;
-        }
-        for (const item of value) {
-          if (item && typeof item === 'object') {
-            if (seen.has(item)) {
-              continue;
-            }
-            seen.add(item);
+  for (const entry of state.leaderboard) {
+    addEntry(entry.modeKey, entry);
+  }
+  for (const entry of state.deathmatchLeaderboard) {
+    addEntry(entry.modeKey, entry);
+  }
+  for (const entry of state.objectiveLeaderboard) {
+    addEntry(entry.modeKey, entry);
+  }
+  for (const entry of state.eliminationLeaderboard) {
+    addEntry(entry.modeKey, entry);
+  }
+
+  const locale = getLocale();
+  modeData.forEach((maps, modeKey) => {
+    const config = MODE_CONFIG_MAP.get(modeKey);
+    maps.forEach((mapData) => {
+      if (config.type === 'race') {
+        mapData.entries.sort((a, b) => {
+          if (a.time !== b.time) {
+            return a.time - b.time;
           }
-          entries.push(item);
-        }
-      }
-      return entries;
-    }
-
-    function extractKillDeath(entry) {
-      if (!entry || typeof entry !== 'object') {
-        return { kills: null, deaths: null };
-      }
-      let kills = numericAtPaths(entry, KILL_PATH_CANDIDATES);
-      let deaths = numericAtPaths(entry, DEATH_PATH_CANDIDATES);
-      if (kills === null) {
-        kills = searchNumericByKeywords(entry, ['kill', 'frag']);
-      }
-      if (deaths === null) {
-        deaths = searchNumericByKeywords(entry, ['death']);
-      }
-      if (kills === null && deaths === null) {
-        return { kills: null, deaths: null };
-      }
-      const safeKills = Math.max(0, kills ?? 0);
-      const safeDeaths = Math.max(0, deaths ?? 0);
-      return { kills: safeKills, deaths: safeDeaths };
-    }
-
-    function priorityIndex(type, priority) {
-      const index = priority.indexOf(type);
-      return index === -1 ? priority.length : index;
-    }
-
-    function extractObjectiveMetric(entry, modeKey) {
-      if (!entry || typeof entry !== 'object') {
-        return { value: null, type: null };
-      }
-      const priority = OBJECTIVE_MODE_PRIORITY[modeKey] || OBJECTIVE_DEFAULT_PRIORITY;
-      for (const type of priority) {
-        const definition = OBJECTIVE_METRIC_DEFINITIONS[type];
-        if (!definition) {
-          continue;
-        }
-        let value = null;
-        if (definition.paths) {
-          value = numericAtPaths(entry, definition.paths);
-        }
-        if (value === null && definition.keywords) {
-          value = searchNumericByKeywords(entry, definition.keywords);
-        }
-        if (value !== null) {
-          return { value: Math.max(0, value), type };
-        }
-      }
-      return { value: null, type: null };
-    }
-
-    function buildLeaderboard() {
-      const bestByKey = new Map();
-
-      for (const match of state.allMatches) {
-        const rawMode = extractMode(match);
-        const modeKey = canonicalMode(rawMode);
-        if (!RACE_MODE_KEYS.has(modeKey)) {
-          continue;
-        }
-
-        const entries = extractScoreboardEntries(match);
-        if (entries.length === 0) {
-          continue;
-        }
-
-        const modeLabel = humanizeMode(rawMode);
-
-        const map = extractMap(match);
-        const mapKey = map.toLowerCase();
-        const matchId = extractMatchId(match);
-        const startedAt = extractStart(match);
-
-        const recordedAt = extractRecordedAtFromMatchId(matchId);
-
-
-        for (const entry of entries) {
-          const player = extractLeaderboardPlayer(entry);
-          if (!player) {
-            continue;
+          return a.player.localeCompare(b.player, locale);
+        });
+      } else if (config.type === 'deathmatch') {
+        mapData.entries.sort((a, b) => {
+          if (b.ratio !== a.ratio) {
+            return b.ratio - a.ratio;
           }
-          const seconds = findBestTime(entry);
-          if (seconds === null || !isReasonableRaceTime(seconds)) {
-            continue;
+          if (b.kills !== a.kills) {
+            return b.kills - a.kills;
           }
-          const key = `${modeKey}||${mapKey}||${player.toLowerCase()}`;
-          const vehicle = extractVehicle(entry);
-          const current = bestByKey.get(key);
-          if (!current || seconds < current.time) {
-            bestByKey.set(key, {
-              player,
-              playerLower: player.toLowerCase(),
-              time: seconds,
-              map,
-              mapKey,
-
-              mode: modeLabel,
-              modeKey,
-              matchId,
-              startedAt,
-              recordedAt,
-
-              vehicle
-            });
+          if (a.deaths !== b.deaths) {
+            return a.deaths - b.deaths;
           }
-        }
-      }
-
-
-      const locale = getLocale();
-
-      state.leaderboard = Array.from(bestByKey.values()).sort((a, b) => {
-        if (a.time !== b.time) {
-          return a.time - b.time;
-        }
-
-        const mapCompare = a.map.localeCompare(b.map, locale);
-        if (mapCompare !== 0) {
-          return mapCompare;
-        }
-        return a.player.localeCompare(b.player, locale);
-
-      });
-      state.filteredLeaderboard = state.leaderboard.slice();
-    }
-
-    function buildDeathmatchLeaderboard() {
-      const bestByKey = new Map();
-
-      for (const match of state.allMatches) {
-        const rawMode = extractMode(match);
-        const modeKey = canonicalMode(rawMode);
-        if (!DEATHMATCH_MODE_KEYS.has(modeKey)) {
-          continue;
-        }
-
-        const entries = extractScoreboardEntries(match);
-        if (entries.length === 0) {
-          continue;
-        }
-
-        const modeLabel = humanizeMode(rawMode);
-        const map = extractMap(match);
-        const mapKey = map.toLowerCase();
-        const matchId = extractMatchId(match);
-        const startedAt = extractStart(match);
-        const recordedAt = extractRecordedAtFromMatchId(matchId);
-
-        for (const entry of entries) {
-          const player = extractLeaderboardPlayer(entry);
-          if (!player) {
-            continue;
-          }
-          const { kills, deaths } = extractKillDeath(entry);
-          if (kills === null && deaths === null) {
-            continue;
-          }
-          const safeKills = kills ?? 0;
-          const safeDeaths = deaths ?? 0;
-          const ratio = safeKills / Math.max(1, safeDeaths);
-          if (!Number.isFinite(ratio)) {
-            continue;
-          }
-          const key = `${modeKey}||${mapKey}||${player.toLowerCase()}`;
-          const current = bestByKey.get(key);
-          const shouldUpdate =
-            !current ||
-            ratio > current.ratio ||
-            (ratio === current.ratio && safeKills > current.kills) ||
-            (ratio === current.ratio && safeKills === current.kills && safeDeaths < current.deaths);
-          if (shouldUpdate) {
-            bestByKey.set(key, {
-              player,
-              playerLower: player.toLowerCase(),
-              ratio,
-              kills: safeKills,
-              deaths: safeDeaths,
-              map,
-              mapKey,
-              mode: modeLabel,
-              modeKey,
-              matchId,
-              startedAt,
-              recordedAt
-            });
-          }
-        }
-      }
-
-      const locale = getLocale();
-      state.deathmatchLeaderboard = Array.from(bestByKey.values()).sort((a, b) => {
-        if (b.ratio !== a.ratio) {
-          return b.ratio - a.ratio;
-        }
-        if (b.kills !== a.kills) {
-          return b.kills - a.kills;
-        }
-        if (a.deaths !== b.deaths) {
-          return a.deaths - b.deaths;
-        }
-        return a.player.localeCompare(b.player, locale);
-      });
-      state.filteredDeathmatchLeaderboard = state.deathmatchLeaderboard.slice();
-    }
-
-    function buildObjectiveLeaderboard() {
-      const bestByKey = new Map();
-      const eliminationBestByKey = new Map();
-
-      for (const match of state.allMatches) {
-        const rawMode = extractMode(match);
-        const modeKey = canonicalMode(rawMode);
-        if (!OBJECTIVE_MODE_KEYS.has(modeKey)) {
-          continue;
-        }
-
-        const entries = extractScoreboardEntries(match);
-        if (entries.length === 0) {
-          continue;
-        }
-
-        const modeLabel = humanizeMode(rawMode);
-        const map = extractMap(match);
-        const mapKey = map.toLowerCase();
-        const matchId = extractMatchId(match);
-        const startedAt = extractStart(match);
-        const recordedAt = extractRecordedAtFromMatchId(matchId);
+          return a.player.localeCompare(b.player, locale);
+        });
+      } else {
         const priority = OBJECTIVE_MODE_PRIORITY[modeKey] || OBJECTIVE_DEFAULT_PRIORITY;
-        const isElimination = modeKey === 'gt_elimination';
-        const targetMap = isElimination ? eliminationBestByKey : bestByKey;
-
-        for (const entry of entries) {
-          const player = extractLeaderboardPlayer(entry);
-          if (!player) {
-            continue;
-          }
-
-          const metric = extractObjectiveMetric(entry, modeKey);
-          if (metric.value === null) {
-            continue;
-          }
-
-          const playerLower = player.toLowerCase();
-          const key = `${modeKey}||${mapKey}||${playerLower}`;
-          const current = targetMap.get(key);
-          const metricPriority = priorityIndex(metric.type, priority);
-          const recordDate = recordedAt || startedAt;
-          const recordTime = recordDate instanceof Date ? recordDate.getTime() : 0;
-
-          let shouldUpdate = false;
-          if (!current) {
-            shouldUpdate = true;
-          } else if (metric.value > current.value) {
-            shouldUpdate = true;
-          } else if (metric.value === current.value) {
-            const currentPriority = priorityIndex(current.metricType, priority);
-            if (metricPriority < currentPriority) {
-              shouldUpdate = true;
-            } else if (metricPriority === currentPriority) {
-              const currentDate = current.recordedAt || current.startedAt;
-              const currentTime = currentDate instanceof Date ? currentDate.getTime() : 0;
-              if (recordTime > currentTime) {
-                shouldUpdate = true;
-              } else if (recordTime === currentTime && playerLower < current.playerLower) {
-                shouldUpdate = true;
-              }
-            }
-          }
-
-          if (shouldUpdate) {
-            targetMap.set(key, {
-              player,
-              playerLower,
-              value: metric.value,
-              metricType: metric.type || 'value',
-              map,
-              mapKey,
-              mode: modeLabel,
-              modeKey,
-              matchId,
-              startedAt,
-              recordedAt
-            });
-          }
-        }
-      }
-
-      const locale = getLocale();
-      function sortObjectiveEntries(map) {
-        return Array.from(map.values()).sort((a, b) => {
+        mapData.entries.sort((a, b) => {
           if (b.value !== a.value) {
             return b.value - a.value;
           }
-          const metricPriorityA = priorityIndex(a.metricType, OBJECTIVE_MODE_PRIORITY[a.modeKey] || OBJECTIVE_DEFAULT_PRIORITY);
-          const metricPriorityB = priorityIndex(b.metricType, OBJECTIVE_MODE_PRIORITY[b.modeKey] || OBJECTIVE_DEFAULT_PRIORITY);
-          if (metricPriorityA !== metricPriorityB) {
-            return metricPriorityA - metricPriorityB;
+          const priorityA = priorityIndex(a.metricType, priority);
+          const priorityB = priorityIndex(b.metricType, priority);
+          if (priorityA !== priorityB) {
+            return priorityA - priorityB;
           }
-          const dateA = (a.recordedAt || a.startedAt);
-          const dateB = (b.recordedAt || b.startedAt);
+          const dateA = a.recordedAt || a.startedAt;
+          const dateB = b.recordedAt || b.startedAt;
           const timeA = dateA instanceof Date ? dateA.getTime() : 0;
           const timeB = dateB instanceof Date ? dateB.getTime() : 0;
           if (timeA !== timeB) {
@@ -2560,920 +1993,909 @@ try {
           return a.player.localeCompare(b.player, locale);
         });
       }
+    });
+  });
 
-      state.objectiveLeaderboard = sortObjectiveEntries(bestByKey);
-      state.filteredObjectiveLeaderboard = state.objectiveLeaderboard.slice();
-      state.eliminationLeaderboard = sortObjectiveEntries(eliminationBestByKey);
-      state.filteredEliminationLeaderboard = state.eliminationLeaderboard.slice();
+  state.modeData = modeData;
+}
+
+function buildRaceLeaderboard() {
+  const bestByKey = new Map();
+  for (const match of state.allMatches) {
+    const rawMode = extractMode(match);
+    const modeKey = canonicalMode(rawMode);
+    if (!RACE_MODE_KEYS.has(modeKey)) {
+      continue;
     }
-
-    function populateSelect(select, defaultLabel, optionsMap, previousValue) {
-      const fragment = document.createDocumentFragment();
-      const defaultOption = document.createElement('option');
-      defaultOption.value = '__all';
-      defaultOption.textContent = defaultLabel;
-      fragment.appendChild(defaultOption);
-
-
-      const locale = getLocale();
-      const sorted = Array.from(optionsMap.entries()).sort((a, b) => a[1].localeCompare(b[1], locale));
-
-      for (const [value, label] of sorted) {
-        const option = document.createElement('option');
-        option.value = value;
-        option.textContent = label;
-        fragment.appendChild(option);
-      }
-
-      select.innerHTML = '';
-      select.appendChild(fragment);
-
-      if (previousValue && previousValue !== '__all' && optionsMap.has(previousValue)) {
-        select.value = previousValue;
-      } else {
-        select.value = '__all';
-      }
+    const entries = extractScoreboardEntries(match);
+    if (!entries.length) {
+      continue;
     }
-
-    function updateLeaderboardFilters() {
-      const previousMode = elements.leaderboardModeFilter.value;
-      const previousMap = elements.leaderboardMapFilter.value;
-
-      const modeOptions = new Map();
-      const mapOptions = new Map();
-
-      for (const entry of state.leaderboard) {
-        if (!modeOptions.has(entry.modeKey)) {
-          modeOptions.set(entry.modeKey, entry.mode);
-        }
-        if (!mapOptions.has(entry.mapKey)) {
-          mapOptions.set(entry.mapKey, entry.map);
-        }
+    const modeLabel = humanizeMode(rawMode);
+    const map = extractMap(match);
+    const mapKey = map.toLowerCase();
+    const matchId = extractMatchId(match);
+    const startedAt = extractStart(match);
+    const recordedAt = extractRecordedAtFromMatchId(matchId);
+    for (const entry of entries) {
+      const player = extractLeaderboardPlayer(entry);
+      if (!player) {
+        continue;
       }
-
-
-      populateSelect(elements.leaderboardModeFilter, t('filters.leaderboard.mode.all'), modeOptions, previousMode);
-      populateSelect(elements.leaderboardMapFilter, t('filters.leaderboard.map.all'), mapOptions, previousMap);
-
-
-      const hasEntries = state.leaderboard.length > 0;
-      elements.leaderboardModeFilter.disabled = !hasEntries;
-      elements.leaderboardMapFilter.disabled = !hasEntries;
-      elements.leaderboardPlayerSearch.disabled = !hasEntries;
-      if (!hasEntries) {
-        elements.leaderboardPlayerSearch.value = '';
+      const seconds = findBestTime(entry);
+      if (seconds === null || !isReasonableRaceTime(seconds)) {
+        continue;
       }
-    }
-
-    function updateDeathmatchFilters() {
-      const previousMode = elements.deathmatchModeFilter.value;
-      const previousMap = elements.deathmatchMapFilter.value;
-
-      const modeOptions = new Map();
-      const mapOptions = new Map();
-
-      for (const entry of state.deathmatchLeaderboard) {
-        if (!modeOptions.has(entry.modeKey)) {
-          modeOptions.set(entry.modeKey, entry.mode);
-        }
-        if (!mapOptions.has(entry.mapKey)) {
-          mapOptions.set(entry.mapKey, entry.map);
-        }
-      }
-
-      populateSelect(elements.deathmatchModeFilter, t('filters.deathmatch.mode.all'), modeOptions, previousMode);
-      populateSelect(elements.deathmatchMapFilter, t('filters.deathmatch.map.all'), mapOptions, previousMap);
-
-      const hasEntries = state.deathmatchLeaderboard.length > 0;
-      elements.deathmatchModeFilter.disabled = !hasEntries;
-      elements.deathmatchMapFilter.disabled = !hasEntries;
-      elements.deathmatchPlayerSearch.disabled = !hasEntries;
-      if (!hasEntries) {
-        elements.deathmatchPlayerSearch.value = '';
-      }
-    }
-
-    function updateEliminationFilters() {
-      const previousMode = elements.eliminationModeFilter.value;
-      const previousMap = elements.eliminationMapFilter.value;
-
-      const modeOptions = new Map();
-      const mapOptions = new Map();
-
-      for (const entry of state.eliminationLeaderboard) {
-        if (!modeOptions.has(entry.modeKey)) {
-          modeOptions.set(entry.modeKey, entry.mode);
-        }
-        if (!mapOptions.has(entry.mapKey)) {
-          mapOptions.set(entry.mapKey, entry.map);
-        }
-      }
-
-      populateSelect(elements.eliminationModeFilter, t('filters.elimination.mode.all'), modeOptions, previousMode);
-      populateSelect(elements.eliminationMapFilter, t('filters.elimination.map.all'), mapOptions, previousMap);
-
-      const hasEntries = state.eliminationLeaderboard.length > 0;
-      elements.eliminationModeFilter.disabled = !hasEntries;
-      elements.eliminationMapFilter.disabled = !hasEntries;
-      elements.eliminationPlayerSearch.disabled = !hasEntries;
-      if (!hasEntries) {
-        elements.eliminationPlayerSearch.value = '';
-      }
-    }
-
-    function updateObjectiveFilters() {
-      const previousMode = elements.ctfModeFilter.value;
-      const previousMap = elements.ctfMapFilter.value;
-
-      const modeOptions = new Map();
-      const mapOptions = new Map();
-
-      for (const entry of state.objectiveLeaderboard) {
-        if (!modeOptions.has(entry.modeKey)) {
-          modeOptions.set(entry.modeKey, entry.mode);
-        }
-        if (!mapOptions.has(entry.mapKey)) {
-          mapOptions.set(entry.mapKey, entry.map);
-        }
-      }
-
-      populateSelect(elements.ctfModeFilter, t('filters.ctf.mode.all'), modeOptions, previousMode);
-      populateSelect(elements.ctfMapFilter, t('filters.ctf.map.all'), mapOptions, previousMap);
-
-      const hasEntries = state.objectiveLeaderboard.length > 0;
-      elements.ctfModeFilter.disabled = !hasEntries;
-      elements.ctfMapFilter.disabled = !hasEntries;
-      elements.ctfPlayerSearch.disabled = !hasEntries;
-      if (!hasEntries) {
-        elements.ctfPlayerSearch.value = '';
-      }
-    }
-
-    function applyLeaderboardFilters() {
-      const mode = elements.leaderboardModeFilter.value;
-      const map = elements.leaderboardMapFilter.value;
-      const playerTerm = elements.leaderboardPlayerSearch.value.trim().toLowerCase();
-
-      state.filteredLeaderboard = state.leaderboard.filter((entry) => {
-        if (mode !== '__all' && entry.modeKey !== mode) {
-          return false;
-        }
-        if (map !== '__all' && entry.mapKey !== map) {
-          return false;
-        }
-        if (playerTerm && !entry.playerLower.includes(playerTerm)) {
-          return false;
-        }
-        return true;
-      });
-
-      renderLeaderboard();
-    }
-
-    function applyDeathmatchFilters() {
-      const mode = elements.deathmatchModeFilter.value;
-      const map = elements.deathmatchMapFilter.value;
-      const playerTerm = elements.deathmatchPlayerSearch.value.trim().toLowerCase();
-
-      state.filteredDeathmatchLeaderboard = state.deathmatchLeaderboard.filter((entry) => {
-        if (mode !== '__all' && entry.modeKey !== mode) {
-          return false;
-        }
-        if (map !== '__all' && entry.mapKey !== map) {
-          return false;
-        }
-        if (playerTerm && !entry.playerLower.includes(playerTerm)) {
-          return false;
-        }
-        return true;
-      });
-
-      renderDeathmatchLeaderboard();
-    }
-
-    function applyEliminationFilters() {
-      const mode = elements.eliminationModeFilter.value;
-      const map = elements.eliminationMapFilter.value;
-      const playerTerm = elements.eliminationPlayerSearch.value.trim().toLowerCase();
-
-      state.filteredEliminationLeaderboard = state.eliminationLeaderboard.filter((entry) => {
-        if (mode !== '__all' && entry.modeKey !== mode) {
-          return false;
-        }
-        if (map !== '__all' && entry.mapKey !== map) {
-          return false;
-        }
-        if (playerTerm && !entry.playerLower.includes(playerTerm)) {
-          return false;
-        }
-        return true;
-      });
-
-      renderEliminationLeaderboard();
-    }
-
-    function applyObjectiveFilters() {
-      const mode = elements.ctfModeFilter.value;
-      const map = elements.ctfMapFilter.value;
-      const playerTerm = elements.ctfPlayerSearch.value.trim().toLowerCase();
-
-      state.filteredObjectiveLeaderboard = state.objectiveLeaderboard.filter((entry) => {
-        if (mode !== '__all' && entry.modeKey !== mode) {
-          return false;
-        }
-        if (map !== '__all' && entry.mapKey !== map) {
-          return false;
-        }
-        if (playerTerm && !entry.playerLower.includes(playerTerm)) {
-          return false;
-        }
-        return true;
-      });
-
-      renderObjectiveLeaderboard();
-    }
-
-    function renderLeaderboard() {
-      const rows = state.filteredLeaderboard;
-      const hasEntries = state.leaderboard.length > 0;
-
-      elements.leaderboardBody.innerHTML = '';
-
-      if (!hasEntries) {
-        elements.leaderboardEmpty.hidden = false;
-
-        elements.leaderboardEmpty.textContent = t('leaderboard.empty.noData');
-        setLeaderboardStatus('leaderboard.status.noneData');
-
-        return;
-      }
-
-      if (!rows.length) {
-        elements.leaderboardEmpty.hidden = false;
-
-        elements.leaderboardEmpty.textContent = t('leaderboard.empty.noFilterMatches');
-        setLeaderboardStatus('leaderboard.status.noFilterMatches');
-
-        return;
-      }
-
-      elements.leaderboardEmpty.hidden = true;
-      const markup = rows.map((entry, index) => {
-        const rank = index + 1;
-
-        const recordDate = entry.recordedAt || entry.startedAt;
-        const dateLabel = recordDate ? formatter.format(recordDate) : '–';
-        const vehicle = entry.vehicle ? `<span>${escapeHtml(entry.vehicle)}</span>` : '';
-        const matchIdLabel = entry.matchId && entry.matchId !== t('common.unknown') ? entry.matchId : '';
-        const matchIdHtml = matchIdLabel ? `<span class="mono" title="${escapeHtml(t('leaderboard.matchId.title'))}">${escapeHtml(matchIdLabel)}</span>` : '';
-
-        return `
-          <tr>
-            <td>${rank}</td>
-            <td>
-              <div class="leaderboard-player">
-                <strong>${escapeHtml(entry.player)}</strong>
-                ${vehicle}
-              </div>
-            </td>
-            <td>${escapeHtml(formatSeconds(entry.time))}</td>
-            <td>${escapeHtml(entry.map)}</td>
-            <td>${escapeHtml(entry.mode)}</td>
-            <td>
-              <div class="meta">
-
-                <span>${escapeHtml(dateLabel)}</span>
-                ${matchIdHtml}
-
-              </div>
-            </td>
-          </tr>
-        `;
-      }).join('');
-
-      elements.leaderboardBody.innerHTML = markup;
-
-      setLeaderboardStatus('leaderboard.status.count', { displayed: rows.length, total: state.leaderboard.length });
-
-    }
-
-    function renderDeathmatchLeaderboard() {
-      const rows = state.filteredDeathmatchLeaderboard;
-      const hasEntries = state.deathmatchLeaderboard.length > 0;
-
-      elements.deathmatchBody.innerHTML = '';
-
-      if (!hasEntries) {
-        elements.deathmatchEmpty.hidden = false;
-        elements.deathmatchEmpty.textContent = t('deathmatch.empty.noData');
-        setDeathmatchStatus('deathmatch.status.noneData');
-        return;
-      }
-
-      if (!rows.length) {
-        elements.deathmatchEmpty.hidden = false;
-        elements.deathmatchEmpty.textContent = t('deathmatch.empty.noFilterMatches');
-        setDeathmatchStatus('deathmatch.status.noFilterMatches');
-        return;
-      }
-
-      elements.deathmatchEmpty.hidden = true;
-      const markup = rows
-        .map((entry, index) => {
-          const rank = index + 1;
-          const recordDate = entry.recordedAt || entry.startedAt;
-          const dateLabel = recordDate ? formatter.format(recordDate) : '–';
-          const matchIdLabel = entry.matchId && entry.matchId !== t('common.unknown') ? entry.matchId : '';
-          const matchIdHtml = matchIdLabel
-            ? `<span class="mono" title="${escapeHtml(t('deathmatch.matchId.title'))}">${escapeHtml(matchIdLabel)}</span>`
-            : '';
-
-          return `
-          <tr>
-            <td>${rank}</td>
-            <td>
-              <div class="leaderboard-player">
-                <strong>${escapeHtml(entry.player)}</strong>
-              </div>
-            </td>
-            <td>${escapeHtml(formatRatio(entry.ratio))}</td>
-            <td>${escapeHtml(formatCount(entry.kills))}</td>
-            <td>${escapeHtml(formatCount(entry.deaths))}</td>
-            <td>${escapeHtml(entry.map)}</td>
-            <td>${escapeHtml(entry.mode)}</td>
-            <td>
-              <div class="meta">
-                <span>${escapeHtml(dateLabel)}</span>
-                ${matchIdHtml}
-              </div>
-            </td>
-          </tr>
-        `;
-        })
-        .join('');
-
-      elements.deathmatchBody.innerHTML = markup;
-      setDeathmatchStatus('deathmatch.status.count', {
-        displayed: rows.length,
-        total: state.deathmatchLeaderboard.length
-      });
-    }
-
-    function renderEliminationLeaderboard() {
-      const rows = state.filteredEliminationLeaderboard;
-      const hasEntries = state.eliminationLeaderboard.length > 0;
-
-      elements.eliminationBody.innerHTML = '';
-
-      if (!hasEntries) {
-        elements.eliminationEmpty.hidden = false;
-        elements.eliminationEmpty.textContent = t('elimination.empty.noData');
-        setEliminationStatus('elimination.status.noneData');
-        return;
-      }
-
-      if (!rows.length) {
-        elements.eliminationEmpty.hidden = false;
-        elements.eliminationEmpty.textContent = t('elimination.empty.noFilterMatches');
-        setEliminationStatus('elimination.status.noFilterMatches');
-        return;
-      }
-
-      elements.eliminationEmpty.hidden = true;
-      const markup = rows
-        .map((entry, index) => {
-          const rank = index + 1;
-          const recordDate = entry.recordedAt || entry.startedAt;
-          const dateLabel = recordDate ? formatter.format(recordDate) : '–';
-          const matchIdLabel = entry.matchId && entry.matchId !== t('common.unknown') ? entry.matchId : '';
-          const matchIdHtml = matchIdLabel
-            ? `<span class="mono" title="${escapeHtml(t('elimination.matchId.title'))}">${escapeHtml(matchIdLabel)}</span>`
-            : '';
-          const metricLabelKey = OBJECTIVE_METRIC_LABEL_KEYS[entry.metricType] || OBJECTIVE_METRIC_LABEL_KEYS.value;
-          const metricLabel = t(metricLabelKey);
-
-          return `
-          <tr>
-            <td>${rank}</td>
-            <td>
-              <div class="leaderboard-player">
-                <strong>${escapeHtml(entry.player)}</strong>
-              </div>
-            </td>
-            <td>
-              <div class="leaderboard-value">
-                <strong>${escapeHtml(formatCount(entry.value))}</strong>
-                <span>${escapeHtml(metricLabel)}</span>
-              </div>
-            </td>
-            <td>${escapeHtml(entry.map)}</td>
-            <td>${escapeHtml(entry.mode)}</td>
-            <td>
-              <div class="meta">
-                <span>${escapeHtml(dateLabel)}</span>
-                ${matchIdHtml}
-              </div>
-            </td>
-          </tr>
-        `;
-        })
-        .join('');
-
-      elements.eliminationBody.innerHTML = markup;
-      setEliminationStatus('elimination.status.count', {
-        displayed: rows.length,
-        total: state.eliminationLeaderboard.length
-      });
-    }
-
-    function renderObjectiveLeaderboard() {
-      const rows = state.filteredObjectiveLeaderboard;
-      const hasEntries = state.objectiveLeaderboard.length > 0;
-
-      elements.ctfBody.innerHTML = '';
-
-      if (!hasEntries) {
-        elements.ctfEmpty.hidden = false;
-        elements.ctfEmpty.textContent = t('ctf.empty.noData');
-        setObjectiveStatus('ctf.status.noneData');
-        return;
-      }
-
-      if (!rows.length) {
-        elements.ctfEmpty.hidden = false;
-        elements.ctfEmpty.textContent = t('ctf.empty.noFilterMatches');
-        setObjectiveStatus('ctf.status.noFilterMatches');
-        return;
-      }
-
-      elements.ctfEmpty.hidden = true;
-      const markup = rows
-        .map((entry, index) => {
-          const rank = index + 1;
-          const recordDate = entry.recordedAt || entry.startedAt;
-          const dateLabel = recordDate ? formatter.format(recordDate) : '–';
-          const matchIdLabel = entry.matchId && entry.matchId !== t('common.unknown') ? entry.matchId : '';
-          const matchIdHtml = matchIdLabel
-            ? `<span class="mono" title="${escapeHtml(t('ctf.matchId.title'))}">${escapeHtml(matchIdLabel)}</span>`
-            : '';
-          const metricLabelKey = OBJECTIVE_METRIC_LABEL_KEYS[entry.metricType] || OBJECTIVE_METRIC_LABEL_KEYS.value;
-          const metricLabel = t(metricLabelKey);
-
-          return `
-          <tr>
-            <td>${rank}</td>
-            <td>
-              <div class="leaderboard-player">
-                <strong>${escapeHtml(entry.player)}</strong>
-              </div>
-            </td>
-            <td>
-              <div class="leaderboard-value">
-                <strong>${escapeHtml(formatCount(entry.value))}</strong>
-                <span>${escapeHtml(metricLabel)}</span>
-              </div>
-            </td>
-            <td>${escapeHtml(entry.map)}</td>
-            <td>${escapeHtml(entry.mode)}</td>
-            <td>
-              <div class="meta">
-                <span>${escapeHtml(dateLabel)}</span>
-                ${matchIdHtml}
-              </div>
-            </td>
-          </tr>
-        `;
-        })
-        .join('');
-
-      elements.ctfBody.innerHTML = markup;
-      setObjectiveStatus('ctf.status.count', {
-        displayed: rows.length,
-        total: state.objectiveLeaderboard.length
-      });
-    }
-
-    function updateModeFilter() {
-      const selected = elements.modeFilter.value;
-      const options = new Map();
-      for (const match of state.allMatches) {
-        const mode = extractMode(match);
-        const key = canonicalMode(mode);
-        if (!options.has(key)) {
-
-          options.set(key, humanizeMode(mode));
-        }
-      }
-
-      const locale = getLocale();
-      const entries = Array.from(options.entries()).sort((a, b) => a[1].localeCompare(b[1], locale));
-      const defaultLabel = t('filters.matches.mode.all');
-      elements.modeFilter.innerHTML = `<option value="__all">${escapeHtml(defaultLabel)}</option>` + entries.map(([value, label]) => `<option value="${escapeHtml(value)}">${escapeHtml(label)}</option>`).join('');
-
-
-      if (entries.some(([value]) => value === selected)) {
-        elements.modeFilter.value = selected;
-      } else {
-        elements.modeFilter.value = '__all';
-      }
-    }
-
-    function updateSummary() {
-      const total = state.allMatches.length;
-      elements.statTotal.textContent = total ? total.toString() : '–';
-
-      const modes = new Set(state.allMatches.map((match) => canonicalMode(extractMode(match))));
-      elements.statModes.textContent = modes.size ? modes.size.toString() : '–';
-
-      const lastDate = state.allMatches
-        .map((match) => extractStart(match))
-        .filter((date) => date instanceof Date && !Number.isNaN(date.getTime()))
-        .sort((a, b) => b.getTime() - a.getTime())[0];
-      elements.statLast.textContent = lastDate ? formatter.format(lastDate) : '–';
-
-      const playerSet = new Set();
-      state.allMatches.forEach((match) => {
-        extractPlayers(match).forEach((name) => playerSet.add(name));
-      });
-      elements.statPlayers.textContent = playerSet.size ? playerSet.size.toString() : '–';
-
-      const breakdown = new Map();
-      state.allMatches.forEach((match) => {
-        const mode = extractMode(match);
-        const key = canonicalMode(mode);
-
-        const label = humanizeMode(mode);
-        const current = breakdown.get(key) || { label, count: 0 };
-        current.label = label;
-
-        current.count += 1;
-        breakdown.set(key, current);
-      });
-      const items = Array.from(breakdown.values()).sort((a, b) => b.count - a.count);
-      if (!items.length) {
-
-        elements.modeBreakdown.innerHTML = `<li>${escapeHtml(t('breakdown.empty'))}</li>`;
-
-      } else {
-        elements.modeBreakdown.innerHTML = items
-          .map((item) => `<li><span>${escapeHtml(item.label)}</span><span>${item.count}</span></li>`)
-          .join('');
-      }
-    }
-
-    function renderMatches() {
-      elements.matches.innerHTML = '';
-      if (!state.filteredMatches.length) {
-
-        elements.matches.innerHTML = `<div class="empty-state">${escapeHtml(t('matches.empty'))}</div>`;
-
-        return;
-      }
-
-      state.filteredMatches.forEach((match) => {
-
-        const rawMode = extractMode(match);
-        const modeLabel = humanizeMode(rawMode);
-
-        const mapName = extractMap(match);
-        const duration = extractDuration(match);
-        const matchId = extractMatchId(match);
-        const players = extractPlayers(match);
-        const date = extractStart(match);
-
-
-        const labels = {
-          map: t('matches.summary.mapLabel'),
-          id: t('matches.summary.idLabel'),
-          start: t('matches.summary.startLabel'),
-          duration: t('matches.summary.durationLabel'),
-          players: t('matches.summary.playersTitle'),
-          server: t('matches.meta.server'),
-          version: t('matches.meta.version'),
-          recorded: t('matches.meta.recorded'),
-          size: t('matches.meta.size')
-        };
-
-        const formattedDate = date ? formatter.format(date) : '–';
-        const durationLabel = duration || '–';
-
-        const details = document.createElement('details');
-        details.className = 'match';
-
-        const summary = document.createElement('summary');
-        summary.innerHTML = `
-
-          <span class="mode-badge">${escapeHtml(modeLabel)}</span>
-          <div class="summary-meta">
-            <span><strong>${escapeHtml(mapName)}</strong>${escapeHtml(labels.map)}</span>
-            <span><strong>${escapeHtml(matchId)}</strong>${escapeHtml(labels.id)}</span>
-            <span><strong>${escapeHtml(formattedDate)}</strong>${escapeHtml(labels.start)}</span>
-            <span><strong>${escapeHtml(durationLabel)}</strong>${escapeHtml(labels.duration)}</span>
-          </div>
-          <span class="players-pill" title="${escapeHtml(labels.players)}">👥 ${players.length}</span>
-
-        `;
-        details.append(summary);
-
-        const body = document.createElement('div');
-        body.className = 'match-body';
-
-        const metaWrapper = document.createElement('div');
-        metaWrapper.className = 'match-meta';
-
-        const metaList = document.createElement('dl');
-        metaList.className = 'meta-list';
-        metaList.innerHTML = `
-
-          <div><dt>${escapeHtml(labels.server)}</dt><dd>${escapeHtml(firstString(match, ['server', 'serverName', 'info.server', 'metadata.server']) || '–')}</dd></div>
-          <div><dt>${escapeHtml(labels.version)}</dt><dd>${escapeHtml(firstString(match, ['version', 'build', 'metadata.version']) || '–')}</dd></div>
-          <div><dt>${escapeHtml(labels.recorded)}</dt><dd>${escapeHtml(firstString(match, ['receivedAt']) || (date ? date.toISOString() : '–'))}</dd></div>
-          <div><dt>${escapeHtml(labels.size)}</dt><dd>${escapeHtml(firstString(match, ['filesize']) || '–')}</dd></div>
-        `;
-
-        const playersBlock = document.createElement('div');
-        const playersHeading = t('matches.players.heading', { count: players.length });
-        playersBlock.innerHTML = `<h3 style="margin:0 0 10px; font-size:0.95rem; letter-spacing:0.04em; text-transform:uppercase; color:var(--text-muted);">${escapeHtml(playersHeading)}</h3>`;
-
-        const playerList = document.createElement('ul');
-        playerList.className = 'players-list';
-        if (players.length) {
-          playerList.innerHTML = players.map((name) => `<li>${escapeHtml(name)}</li>`).join('');
-        } else {
-
-          playerList.innerHTML = `<li>${escapeHtml(t('matches.players.empty'))}</li>`;
-
-        }
-        playersBlock.append(playerList);
-
-        metaWrapper.append(metaList, playersBlock);
-
-        const pre = document.createElement('pre');
-        pre.className = 'payload';
-        pre.textContent = JSON.stringify(match, null, 2);
-
-        body.append(metaWrapper, pre);
-        details.append(body);
-
-        elements.matches.append(details);
-      });
-    }
-
-    function applyFilters() {
-      const selectedMode = elements.modeFilter.value;
-      const term = elements.searchInput.value.trim().toLowerCase();
-
-      let matches = state.allMatches.slice();
-      if (selectedMode !== '__all') {
-        matches = matches.filter((match) => canonicalMode(extractMode(match)) === selectedMode);
-      }
-
-      if (term) {
-        matches = matches.filter((match) => {
-          const mapName = extractMap(match).toLowerCase();
-          const matchId = extractMatchId(match).toLowerCase();
-
-          const rawMode = extractMode(match);
-          const mode = rawMode.toLowerCase();
-          const modeLabel = humanizeMode(rawMode).toLowerCase();
-          const players = extractPlayers(match).map((name) => name.toLowerCase());
-          return [mapName, matchId, mode, modeLabel, ...players].some((value) => value.includes(term));
-
+      const key = `${modeKey}||${mapKey}||${player.toLowerCase()}`;
+      const vehicle = extractVehicle(entry);
+      const current = bestByKey.get(key);
+      if (!current || seconds < current.time) {
+        bestByKey.set(key, {
+          player,
+          playerLower: player.toLowerCase(),
+          time: seconds,
+          map,
+          mapKey,
+          mode: modeLabel,
+          modeKey,
+          matchId,
+          startedAt,
+          recordedAt,
+          vehicle
         });
       }
+    }
+  }
+  const locale = getLocale();
+  state.leaderboard = Array.from(bestByKey.values()).sort((a, b) => {
+    if (a.time !== b.time) {
+      return a.time - b.time;
+    }
+    const mapCompare = a.map.localeCompare(b.map, locale);
+    if (mapCompare !== 0) {
+      return mapCompare;
+    }
+    return a.player.localeCompare(b.player, locale);
+  });
+}
 
-      matches.sort((a, b) => {
-        const dateA = extractStart(a);
-        const dateB = extractStart(b);
-        const timeA = dateA ? dateA.getTime() : 0;
-        const timeB = dateB ? dateB.getTime() : 0;
+function buildDeathmatchLeaderboard() {
+  const bestByKey = new Map();
+  for (const match of state.allMatches) {
+    const rawMode = extractMode(match);
+    const modeKey = canonicalMode(rawMode);
+    if (!DEATHMATCH_MODE_KEYS.has(modeKey)) {
+      continue;
+    }
+    const entries = extractScoreboardEntries(match);
+    if (!entries.length) {
+      continue;
+    }
+    const modeLabel = humanizeMode(rawMode);
+    const map = extractMap(match);
+    const mapKey = map.toLowerCase();
+    const matchId = extractMatchId(match);
+    const startedAt = extractStart(match);
+    const recordedAt = extractRecordedAtFromMatchId(matchId);
+    for (const entry of entries) {
+      const player = extractLeaderboardPlayer(entry);
+      if (!player) {
+        continue;
+      }
+      const { kills, deaths } = extractKillDeath(entry);
+      if (kills === null && deaths === null) {
+        continue;
+      }
+      const safeKills = kills ?? 0;
+      const safeDeaths = deaths ?? 0;
+      const ratio = safeKills / Math.max(1, safeDeaths);
+      if (!Number.isFinite(ratio)) {
+        continue;
+      }
+      const key = `${modeKey}||${mapKey}||${player.toLowerCase()}`;
+      const current = bestByKey.get(key);
+      const shouldUpdate =
+        !current ||
+        ratio > current.ratio ||
+        (ratio === current.ratio && safeKills > current.kills) ||
+        (ratio === current.ratio && safeKills === current.kills && safeDeaths < current.deaths);
+      if (shouldUpdate) {
+        bestByKey.set(key, {
+          player,
+          playerLower: player.toLowerCase(),
+          ratio,
+          kills: safeKills,
+          deaths: safeDeaths,
+          map,
+          mapKey,
+          mode: modeLabel,
+          modeKey,
+          matchId,
+          startedAt,
+          recordedAt
+        });
+      }
+    }
+  }
+  const locale = getLocale();
+  state.deathmatchLeaderboard = Array.from(bestByKey.values()).sort((a, b) => {
+    if (b.ratio !== a.ratio) {
+      return b.ratio - a.ratio;
+    }
+    if (b.kills !== a.kills) {
+      return b.kills - a.kills;
+    }
+    if (a.deaths !== b.deaths) {
+      return a.deaths - b.deaths;
+    }
+    return a.player.localeCompare(b.player, locale);
+  });
+}
+
+function buildObjectiveLeaderboard() {
+  const bestByKey = new Map();
+  const eliminationBestByKey = new Map();
+  for (const match of state.allMatches) {
+    const rawMode = extractMode(match);
+    const modeKey = canonicalMode(rawMode);
+    if (!OBJECTIVE_MODE_KEYS.has(modeKey)) {
+      continue;
+    }
+    const entries = extractScoreboardEntries(match);
+    if (!entries.length) {
+      continue;
+    }
+    const modeLabel = humanizeMode(rawMode);
+    const map = extractMap(match);
+    const mapKey = map.toLowerCase();
+    const matchId = extractMatchId(match);
+    const startedAt = extractStart(match);
+    const recordedAt = extractRecordedAtFromMatchId(matchId);
+    const priority = OBJECTIVE_MODE_PRIORITY[modeKey] || OBJECTIVE_DEFAULT_PRIORITY;
+    const isElimination = modeKey === 'gt_elimination';
+    const targetMap = isElimination ? eliminationBestByKey : bestByKey;
+    for (const entry of entries) {
+      const player = extractLeaderboardPlayer(entry);
+      if (!player) {
+        continue;
+      }
+      const metric = extractObjectiveMetric(entry, modeKey);
+      if (metric.value === null) {
+        continue;
+      }
+      const playerLower = player.toLowerCase();
+      const key = `${modeKey}||${mapKey}||${playerLower}`;
+      const current = targetMap.get(key);
+      const metricPriority = priorityIndex(metric.type, priority);
+      const recordDate = recordedAt || startedAt;
+      const recordTime = recordDate instanceof Date ? recordDate.getTime() : 0;
+      let shouldUpdate = false;
+      if (!current) {
+        shouldUpdate = true;
+      } else if (metric.value > current.value) {
+        shouldUpdate = true;
+      } else if (metric.value === current.value) {
+        const currentPriority = priorityIndex(current.metricType, priority);
+        if (metricPriority < currentPriority) {
+          shouldUpdate = true;
+        } else if (metricPriority === currentPriority) {
+          const currentDate = current.recordedAt || current.startedAt;
+          const currentTime = currentDate instanceof Date ? currentDate.getTime() : 0;
+          if (recordTime > currentTime) {
+            shouldUpdate = true;
+          } else if (recordTime === currentTime && playerLower < current.playerLower) {
+            shouldUpdate = true;
+          }
+        }
+      }
+      if (shouldUpdate) {
+        targetMap.set(key, {
+          player,
+          playerLower,
+          value: metric.value,
+          metricType: metric.type || 'value',
+          map,
+          mapKey,
+          mode: modeLabel,
+          modeKey,
+          matchId,
+          startedAt,
+          recordedAt
+        });
+      }
+    }
+  }
+  const locale = getLocale();
+  function sortObjectiveEntries(map) {
+    return Array.from(map.values()).sort((a, b) => {
+      if (b.value !== a.value) {
+        return b.value - a.value;
+      }
+      const metricPriorityA = priorityIndex(a.metricType, OBJECTIVE_MODE_PRIORITY[a.modeKey] || OBJECTIVE_DEFAULT_PRIORITY);
+      const metricPriorityB = priorityIndex(b.metricType, OBJECTIVE_MODE_PRIORITY[b.modeKey] || OBJECTIVE_DEFAULT_PRIORITY);
+      if (metricPriorityA !== metricPriorityB) {
+        return metricPriorityA - metricPriorityB;
+      }
+      const dateA = a.recordedAt || a.startedAt;
+      const dateB = b.recordedAt || b.startedAt;
+      const timeA = dateA instanceof Date ? dateA.getTime() : 0;
+      const timeB = dateB instanceof Date ? dateB.getTime() : 0;
+      if (timeA !== timeB) {
         return timeB - timeA;
-      });
-
-      state.filteredMatches = matches;
-      renderMatches();
-    }
-
-    function resolveLimitSelection() {
-      const value = elements.limitSelect.value;
-      if (value === 'all') {
-        return 'all';
       }
-      const numeric = parseInt(value, 10);
-      return numeric > 0 ? numeric : 100;
+      return a.player.localeCompare(b.player, locale);
+    });
+  }
+  state.objectiveLeaderboard = sortObjectiveEntries(bestByKey);
+  state.eliminationLeaderboard = sortObjectiveEntries(eliminationBestByKey);
+}
+
+function updateSummary() {
+  const total = state.allMatches.length;
+  elements.statTotal.textContent = total ? total.toString() : '–';
+  const modes = new Set(state.allMatches.map((match) => canonicalMode(extractMode(match))));
+  elements.statModes.textContent = modes.size ? modes.size.toString() : '–';
+  const lastDate = state.allMatches
+    .map((match) => extractStart(match))
+    .filter((date) => date instanceof Date && !Number.isNaN(date.getTime()))
+    .sort((a, b) => b.getTime() - a.getTime())[0];
+  elements.statLast.textContent = lastDate ? formatter.format(lastDate) : '–';
+  const playerSet = new Set();
+  state.allMatches.forEach((match) => {
+    extractPlayers(match).forEach((name) => playerSet.add(name));
+  });
+  elements.statPlayers.textContent = playerSet.size ? playerSet.size.toString() : '–';
+  const breakdown = new Map();
+  state.allMatches.forEach((match) => {
+    const mode = extractMode(match);
+    const key = canonicalMode(mode);
+    const label = humanizeMode(mode);
+    const current = breakdown.get(key) || { label, count: 0 };
+    current.label = label;
+    current.count += 1;
+    breakdown.set(key, current);
+  });
+  const items = Array.from(breakdown.values()).sort((a, b) => b.count - a.count);
+  if (!items.length) {
+    elements.modeBreakdown.innerHTML = `<li>${escapeHtml(t('breakdown.empty'))}</li>`;
+  } else {
+    elements.modeBreakdown.innerHTML = items
+      .map((item) => `<li><span>${escapeHtml(item.label)}</span><span>${item.count}</span></li>`)
+      .join('');
+  }
+}
+
+async function loadMatches() {
+    setModeStatus('mode.status.loading');
+  try {
+    const response = await fetch(`${API_BASE}/matches?limit=all`);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
     }
+    const payload = await response.json();
+    if (!payload || !Array.isArray(payload.matches)) {
+      throw new Error(t('errors.unexpectedResponse'));
+    }
+    state.allMatches = payload.matches;
+    if (!state.allMatches.length) {
+      state.leaderboard = [];
+      state.deathmatchLeaderboard = [];
+      state.objectiveLeaderboard = [];
+      state.eliminationLeaderboard = [];
+      state.modeData = new Map();
+      updateSummary();
+      updateModeOptions();
+      MODE_CONFIG.forEach(({ key }) => renderModeTable(key));
+      setModeStatus('mode.status.empty');
+      return;
+    }
+    buildRaceLeaderboard();
+    buildDeathmatchLeaderboard();
+    buildObjectiveLeaderboard();
+    prepareModeData();
+    updateSummary();
+    updateModeOptions();
+    MODE_CONFIG.forEach(({ key }) => renderModeTable(key));
+    setModeStatus('mode.status.ready', { count: state.allMatches.length });
+  } catch (error) {
+    console.error(error);
+    state.allMatches = [];
+    state.leaderboard = [];
+    state.deathmatchLeaderboard = [];
+    state.objectiveLeaderboard = [];
+    state.eliminationLeaderboard = [];
+    state.modeData = new Map();
+    updateSummary();
+    updateModeOptions();
+    MODE_CONFIG.forEach(({ key }) => renderModeTable(key));
+    setModeStatus('mode.status.error', { message: error.message }, true);
+  }
+}
 
-    async function loadMatches() {
-      state.limit = resolveLimitSelection();
+function escapeHtml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
 
-      setStatus('status.loadingMatches');
-      setLeaderboardStatus('leaderboard.status.loading');
-      setDeathmatchStatus('deathmatch.status.loading');
-      setEliminationStatus('elimination.status.loading');
-      setObjectiveStatus('ctf.status.loading');
+function canonicalMode(mode) {
+  if (typeof mode !== 'string') {
+    return '__unknown__';
+  }
+  const trimmed = mode.trim();
+  if (!trimmed) {
+    return '__unknown__';
+  }
+  return trimmed.toLowerCase();
+}
 
-      elements.refreshButton.disabled = true;
-      try {
-        const limitParam = state.limit === 'all' ? 'all' : String(state.limit);
-        const response = await fetch(`${API_BASE}/matches?limit=${encodeURIComponent(limitParam)}`);
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-        const payload = await response.json();
-        if (!payload || !Array.isArray(payload.matches)) {
+function humanizeMode(mode) {
+  if (typeof mode !== 'string') {
+    return t('mode.unknown');
+  }
+  const trimmed = mode.trim();
+  if (!trimmed) {
+    return t('mode.unknown');
+  }
+  const key = trimmed.toLowerCase();
+  const translations = MODE_TRANSLATIONS[state.language] || {};
+  if (Object.prototype.hasOwnProperty.call(translations, key)) {
+    return translations[key];
+  }
+  const withoutPrefix = trimmed.replace(/^GT[_\-\s]?/i, '');
+  const normalized = withoutPrefix.replace(/[_\-]+/g, ' ').toLowerCase();
+  const locale = getLocale();
+  return normalized.replace(/(^|\s)([\p{L}])/gu, (match, prefix, char) => prefix + char.toLocaleUpperCase(locale));
+}
 
-          throw new Error(t('errors.unexpectedResponse'));
-        }
-        state.allMatches = payload.matches;
-        if (!state.allMatches.length) {
-          setStatus('status.noMatches');
-        } else {
-          setStatus('status.lastUpdated', { timestamp: formatter.format(new Date()) });
-        }
-        updateModeFilter();
-        updateSummary();
-        buildLeaderboard();
-        updateLeaderboardFilters();
-        applyLeaderboardFilters();
+function isReasonableRaceTime(seconds) {
+  return Number.isFinite(seconds) && seconds > 0 && seconds < MAX_REASONABLE_TIME;
+}
 
-        buildDeathmatchLeaderboard();
-        updateDeathmatchFilters();
-        applyDeathmatchFilters();
+function parseTimeToSeconds(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'number') {
+    const abs = Math.abs(value);
+    if (!Number.isFinite(abs) || abs === 0) {
+      return null;
+    }
+    if (abs < MAX_REASONABLE_TIME) {
+      return abs;
+    }
+    if (abs >= 600 && abs < MAX_REASONABLE_TIME * 1000) {
+      return abs / 1000;
+    }
+    if (abs >= 600 && abs < MAX_REASONABLE_TIME * 1_000_000) {
+      return abs / 1_000_000;
+    }
+    return null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      return null;
+    }
+    const normalized = trimmed.replace(',', '.');
+    const numeric = Number(normalized);
+    if (!Number.isNaN(numeric)) {
+      return parseTimeToSeconds(numeric);
+    }
+    const msMatch = normalized.match(/^([0-9]+(?:\.[0-9]+)?)\s*ms$/i);
+    if (msMatch) {
+      return parseFloat(msMatch[1]) / 1000;
+    }
+    const secMatch = normalized.match(/^([0-9]+(?:\.[0-9]+)?)\s*s$/i);
+    if (secMatch) {
+      return parseFloat(secMatch[1]);
+    }
+    const minuteMatch = normalized.match(/^([0-9]+)\s*m(?:in)?\s*([0-9]+(?:\.[0-9]+)?)\s*s$/i);
+    if (minuteMatch) {
+      return Number(minuteMatch[1]) * 60 + Number(minuteMatch[2]);
+    }
+    const isoMatch = normalized.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?$/i);
+    if (isoMatch) {
+      const hours = isoMatch[1] ? Number(isoMatch[1]) : 0;
+      const minutes = isoMatch[2] ? Number(isoMatch[2]) : 0;
+      const seconds = isoMatch[3] ? Number(isoMatch[3]) : 0;
+      return hours * 3600 + minutes * 60 + seconds;
+    }
+    const colonMatch = normalized.match(/^(\d+):(\d{2})(?::(\d{2}))?(?:\.(\d+))?$/);
+    if (colonMatch) {
+      const first = Number(colonMatch[1]);
+      const second = Number(colonMatch[2]);
+      const third = colonMatch[3] !== undefined ? Number(colonMatch[3]) : null;
+      const fraction = colonMatch[4] ? Number(`0.${colonMatch[4]}`) : 0;
+      if (third !== null) {
+        return first * 3600 + second * 60 + third + fraction;
+      }
+      return first * 60 + second + fraction;
+    }
+    const simpleMinuteMatch = normalized.match(/^([0-9]+)m(?:in)?$/i);
+    if (simpleMinuteMatch) {
+      return Number(simpleMinuteMatch[1]) * 60;
+    }
+    return null;
+  }
+  return null;
+}
 
-        buildObjectiveLeaderboard();
-        updateEliminationFilters();
-        updateObjectiveFilters();
-        applyEliminationFilters();
-        applyObjectiveFilters();
-
-        applyFilters();
-      } catch (error) {
-        console.error(error);
-        state.allMatches = [];
-
-        setStatus('status.error', { message: error.message }, true);
-
-        state.leaderboard = [];
-        state.filteredLeaderboard = [];
-        state.deathmatchLeaderboard = [];
-        state.filteredDeathmatchLeaderboard = [];
-        state.objectiveLeaderboard = [];
-        state.filteredObjectiveLeaderboard = [];
-        state.eliminationLeaderboard = [];
-        state.filteredEliminationLeaderboard = [];
-        updateModeFilter();
-        updateSummary();
-        updateLeaderboardFilters();
-        renderLeaderboard();
-        updateDeathmatchFilters();
-        renderDeathmatchLeaderboard();
-        updateEliminationFilters();
-        renderEliminationLeaderboard();
-        updateObjectiveFilters();
-        renderObjectiveLeaderboard();
-        applyFilters();
-
-        setLeaderboardStatus('leaderboard.status.error', { message: error.message }, true);
-        setDeathmatchStatus('deathmatch.status.error', { message: error.message }, true);
-        setEliminationStatus('elimination.status.error', { message: error.message }, true);
-        setObjectiveStatus('ctf.status.error', { message: error.message }, true);
-
-      } finally {
-        elements.refreshButton.disabled = false;
+function findBestTime(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  let best = null;
+  for (const path of TIME_PATH_CANDIDATES) {
+    const candidate = valueAtPath(entry, path);
+    const seconds = parseTimeToSeconds(candidate);
+    if (seconds !== null && isReasonableRaceTime(seconds)) {
+      if (best === null || seconds < best) {
+        best = seconds;
       }
     }
-
-    function setActiveTab(tab) {
-      if (!elements.tabPanels[tab]) {
+  }
+  if (best !== null) {
+    return best;
+  }
+  const visited = new Set();
+  function walk(node, hint = '') {
+    if (node === null || node === undefined) {
+      return;
+    }
+    if (typeof node === 'number' || typeof node === 'string') {
+      const keyHint = String(hint).toLowerCase();
+      if (keyHint.includes('time') || keyHint.includes('lap') || keyHint.includes('duration')) {
+        const seconds = parseTimeToSeconds(node);
+        if (seconds !== null && isReasonableRaceTime(seconds)) {
+          if (best === null || seconds < best) {
+            best = seconds;
+          }
+        }
+      }
+      return;
+    }
+    if (typeof node === 'object') {
+      if (visited.has(node)) {
         return;
       }
-      state.activeTab = tab;
-      elements.tabButtons.forEach((button) => {
-        const isActive = button.dataset.tab === tab;
-        button.classList.toggle('active', isActive);
-        button.setAttribute('aria-selected', String(isActive));
-        button.setAttribute('tabindex', isActive ? '0' : '-1');
-      });
-      Object.entries(elements.tabPanels).forEach(([key, panel]) => {
-        panel.classList.toggle('active', key === tab);
-      });
-    }
-
-    elements.tabButtons.forEach((button, index) => {
-      button.addEventListener('click', () => {
-        setActiveTab(button.dataset.tab);
-      });
-      button.addEventListener('keydown', (event) => {
-        if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
-          event.preventDefault();
-          const direction = event.key === 'ArrowRight' ? 1 : -1;
-          const nextIndex = (index + direction + elements.tabButtons.length) % elements.tabButtons.length;
-          const nextButton = elements.tabButtons[nextIndex];
-          nextButton.focus();
-          setActiveTab(nextButton.dataset.tab);
+      visited.add(node);
+      if (Array.isArray(node)) {
+        for (const item of node) {
+          walk(item, hint);
         }
-      });
-    });
-
-
-    elements.languageButtons.forEach((button) => {
-      button.addEventListener('click', () => {
-        const lang = button.dataset.lang;
-        if (lang && lang !== state.language) {
-          applyLanguage(lang);
-        }
-      });
-    });
-
-    elements.leaderboardModeFilter.addEventListener('change', () => {
-      applyLeaderboardFilters();
-    });
-
-    elements.leaderboardMapFilter.addEventListener('change', () => {
-      applyLeaderboardFilters();
-    });
-
-    elements.leaderboardPlayerSearch.addEventListener('input', () => {
-      applyLeaderboardFilters();
-    });
-
-    elements.deathmatchModeFilter.addEventListener('change', () => {
-      applyDeathmatchFilters();
-    });
-
-    elements.deathmatchMapFilter.addEventListener('change', () => {
-      applyDeathmatchFilters();
-    });
-
-    elements.deathmatchPlayerSearch.addEventListener('input', () => {
-      applyDeathmatchFilters();
-    });
-
-    elements.eliminationModeFilter.addEventListener('change', () => {
-      applyEliminationFilters();
-    });
-
-    elements.eliminationMapFilter.addEventListener('change', () => {
-      applyEliminationFilters();
-    });
-
-    elements.eliminationPlayerSearch.addEventListener('input', () => {
-      applyEliminationFilters();
-    });
-
-    elements.ctfModeFilter.addEventListener('change', () => {
-      applyObjectiveFilters();
-    });
-
-    elements.ctfMapFilter.addEventListener('change', () => {
-      applyObjectiveFilters();
-    });
-
-    elements.ctfPlayerSearch.addEventListener('input', () => {
-      applyObjectiveFilters();
-    });
-
-    elements.modeFilter.addEventListener('change', () => {
-      applyFilters();
-    });
-
-    elements.searchInput.addEventListener('input', () => {
-      applyFilters();
-    });
-
-    elements.limitSelect.addEventListener('change', () => {
-      loadMatches();
-    });
-
-    elements.refreshButton.addEventListener('click', () => {
-      loadMatches();
-    });
-
-    document.addEventListener('keydown', (event) => {
-      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
-        event.preventDefault();
-
-        if (state.activeTab === 'leaderboard' && !elements.leaderboardPlayerSearch.disabled) {
-          elements.leaderboardPlayerSearch.focus();
-        } else {
-          if (state.activeTab !== 'matches') {
-            setActiveTab('matches');
-          }
-          elements.searchInput.focus();
-        }
+        return;
       }
-    });
+      for (const [key, value] of Object.entries(node)) {
+        walk(value, key);
+      }
+    }
+  }
+  walk(entry, '');
+  return best;
+}
 
+function extractLeaderboardPlayer(entry) {
+  if (entry === null || entry === undefined) {
+    return '';
+  }
+  if (typeof entry === 'string') {
+    return entry.trim();
+  }
+  if (typeof entry !== 'object') {
+    return '';
+  }
+  const name = firstString(entry, PLAYER_PATH_CANDIDATES);
+  if (name) {
+    return name;
+  }
+  if (entry.stats && typeof entry.stats === 'object') {
+    return firstString(entry.stats, PLAYER_PATH_CANDIDATES);
+  }
+  if (entry.result && typeof entry.result === 'object') {
+    return firstString(entry.result, PLAYER_PATH_CANDIDATES);
+  }
+  return '';
+}
 
-    applyLanguage(state.language);
-    setStatus('status.loadingMatches');
-    setLeaderboardStatus('leaderboard.status.waiting');
-    setDeathmatchStatus('deathmatch.status.waiting');
-    setEliminationStatus('elimination.status.waiting');
-    setObjectiveStatus('ctf.status.waiting');
-    setActiveTab(state.activeTab);
+function extractVehicle(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return '';
+  }
+  const vehicle = firstString(entry, VEHICLE_PATH_CANDIDATES);
+  if (vehicle) {
+    return vehicle;
+  }
+  if (entry.stats && typeof entry.stats === 'object') {
+    return firstString(entry.stats, VEHICLE_PATH_CANDIDATES);
+  }
+  if (entry.result && typeof entry.result === 'object') {
+    return firstString(entry.result, VEHICLE_PATH_CANDIDATES);
+  }
+  return '';
+}
 
-    loadMatches();
+function formatSeconds(seconds) {
+  if (!Number.isFinite(seconds)) {
+    return '–';
+  }
+  const totalMilliseconds = Math.round(seconds * 1000);
+  const hours = Math.floor(totalMilliseconds / 3_600_000);
+  const minutes = Math.floor((totalMilliseconds % 3_600_000) / 60_000);
+  const secs = Math.floor((totalMilliseconds % 60_000) / 1000);
+  const millis = totalMilliseconds % 1000;
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}`;
+  }
+  return `${minutes}:${secs.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}`;
+}
+
+function extractKillDeath(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return { kills: null, deaths: null };
+  }
+  let kills = numericAtPaths(entry, KILL_PATH_CANDIDATES);
+  let deaths = numericAtPaths(entry, DEATH_PATH_CANDIDATES);
+  if (kills === null) {
+    kills = searchNumericByKeywords(entry, ['kill', 'frag']);
+  }
+  if (deaths === null) {
+    deaths = searchNumericByKeywords(entry, ['death']);
+  }
+  if (kills === null && deaths === null) {
+    return { kills: null, deaths: null };
+  }
+  const safeKills = Math.max(0, kills ?? 0);
+  const safeDeaths = Math.max(0, deaths ?? 0);
+  return { kills: safeKills, deaths: safeDeaths };
+}
+
+function priorityIndex(type, priority) {
+  const index = priority.indexOf(type);
+  return index === -1 ? priority.length : index;
+}
+
+function extractObjectiveMetric(entry, modeKey) {
+  if (!entry || typeof entry !== 'object') {
+    return { value: null, type: null };
+  }
+  const priority = OBJECTIVE_MODE_PRIORITY[modeKey] || OBJECTIVE_DEFAULT_PRIORITY;
+  for (const type of priority) {
+    const definition = OBJECTIVE_METRIC_DEFINITIONS[type];
+    if (!definition) {
+      continue;
+    }
+    let value = null;
+    if (definition.paths) {
+      value = numericAtPaths(entry, definition.paths);
+    }
+    if (value === null && definition.keywords) {
+      value = searchNumericByKeywords(entry, definition.keywords);
+    }
+    if (value !== null) {
+      return { value: Math.max(0, value), type };
+    }
+  }
+  return { value: null, type: null };
+}
+
+function valueAtPath(obj, path) {
+  const parts = path.split('.');
+  let current = obj;
+  for (const part of parts) {
+    if (current && Object.prototype.hasOwnProperty.call(current, part)) {
+      current = current[part];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+function firstString(obj, paths) {
+  for (const path of paths) {
+    const value = valueAtPath(obj, path);
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value.trim();
+    }
+  }
+  return '';
+}
+
+function firstNumber(obj, paths) {
+  for (const path of paths) {
+    const value = valueAtPath(obj, path);
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) {
+      return Number(value);
+    }
+  }
+  return null;
+}
+
+function pickArray(obj, paths) {
+  for (const path of paths) {
+    const value = valueAtPath(obj, path);
+    if (Array.isArray(value)) {
+      return value;
+    }
+  }
+  return [];
+}
+
+function parseNumericValue(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().replace(',', '.');
+    if (normalized === '') {
+      return null;
+    }
+    const numeric = Number(normalized);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+  return null;
+}
+
+function numericAtPaths(obj, paths) {
+  for (const path of paths) {
+    const value = valueAtPath(obj, path);
+    const numeric = parseNumericValue(value);
+    if (numeric !== null) {
+      return numeric;
+    }
+  }
+  return null;
+}
+
+function searchNumericByKeywords(node, keywords, visited = new Set()) {
+  if (node === null || node === undefined) {
+    return null;
+  }
+  if (typeof node !== 'object') {
+    return null;
+  }
+  if (visited.has(node)) {
+    return null;
+  }
+  visited.add(node);
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const result = searchNumericByKeywords(item, keywords, visited);
+      if (result !== null) {
+        return result;
+      }
+    }
+    return null;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    const lowerKey = key.toLowerCase();
+    if (keywords.some((keyword) => lowerKey.includes(keyword))) {
+      const numeric = parseNumericValue(value);
+      if (numeric !== null) {
+        return numeric;
+      }
+    }
+    const nested = searchNumericByKeywords(value, keywords, visited);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+  return null;
+}
+
+function searchStringByKeywords(node, keywords, visited = new Set()) {
+  if (node === null || node === undefined) {
+    return '';
+  }
+  if (typeof node === 'string') {
+    return node.trim();
+  }
+  if (typeof node !== 'object') {
+    return '';
+  }
+  if (visited.has(node)) {
+    return '';
+  }
+  visited.add(node);
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const found = searchStringByKeywords(item, keywords, visited);
+      if (found) {
+        return found;
+      }
+    }
+    return '';
+  }
+  for (const [key, value] of Object.entries(node)) {
+    const lowerKey = key.toLowerCase();
+    if (keywords.some((keyword) => lowerKey.includes(keyword))) {
+      if (typeof value === 'string' && value.trim() !== '') {
+        return value.trim();
+      }
+    }
+    const nested = searchStringByKeywords(value, keywords, visited);
+    if (nested) {
+      return nested;
+    }
+  }
+  return '';
+}
+
+function extractMode(match) {
+  return firstString(match, [
+    'mode',
+    'match.mode',
+    'gameMode',
+    'game_type',
+    'type'
+  ]) || '__unknown__';
+}
+
+function extractMap(match) {
+  return firstString(match, [
+    'map',
+    'mapName',
+    'match.map',
+    'metadata.map',
+    'level',
+    'settings.map',
+    'info.map'
+  ]) || '–';
+}
+
+function extractScoreboardEntries(match) {
+  const entries = [];
+  const seen = new Set();
+  for (const path of SCOREBOARD_PATHS) {
+    const value = valueAtPath(match, path);
+    if (!Array.isArray(value) || value.length === 0) {
+      continue;
+    }
+    for (const item of value) {
+      if (item && typeof item === 'object') {
+        if (seen.has(item)) {
+          continue;
+        }
+        seen.add(item);
+      }
+      entries.push(item);
+    }
+  }
+  return entries;
+}
+
+function extractStart(match) {
+  const candidate = firstString(match, [
+    'startTime',
+    'match.startTime',
+    'startedAt',
+    'match.startedAt',
+    'serverStartTime',
+    'start',
+    'matchStart',
+    'info.started',
+    'receivedAt'
+  ]);
+  const numeric = firstNumber(match, [
+    'startTimestamp',
+    'startedAtUnix',
+    'timestamps.start',
+    'match.startTimestamp'
+  ]);
+  return parseDate(candidate || numeric || match.receivedAt || null);
+}
+
+function extractMatchId(match) {
+  const id = firstString(match, [
+    'matchId',
+    'id',
+    'match.id',
+    'identifier',
+    'metadata.id'
+  ]);
+  return id || t('common.unknown');
+}
+
+function extractRecordedAtFromMatchId(matchId) {
+  if (typeof matchId !== 'string') {
+    return null;
+  }
+  const digits = matchId.replace(/\D+/g, '');
+  if (digits.length < 12) {
+    return null;
+  }
+  const year = Number(digits.slice(0, 4));
+  const month = Number(digits.slice(4, 6)) - 1;
+  const day = Number(digits.slice(6, 8));
+  const hour = Number(digits.slice(8, 10));
+  const minute = Number(digits.slice(10, 12));
+  const second = digits.length >= 14 ? Number(digits.slice(12, 14)) : 0;
+  if (
+    [year, month, day, hour, minute, second].some((part) => Number.isNaN(part)) ||
+    month < 0 || month > 11 ||
+    day < 1 || day > 31 ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59
+  ) {
+    return null;
+  }
+  const candidate = new Date(year, month, day, hour, minute, second);
+  return Number.isNaN(candidate.getTime()) ? null : candidate;
+}
+
+function extractPlayers(match) {
+  const candidates = pickArray(match, [
+    'players',
+    'match.players',
+    'participants',
+    'scoreboard',
+    'results',
+    'leaderboard'
+  ]);
+  if (!candidates.length) {
+    return [];
+  }
+  return candidates
+    .map((entry) => {
+      if (typeof entry === 'string') {
+        return entry.trim();
+      }
+      if (entry && typeof entry === 'object') {
+        const name = firstString(entry, PLAYER_PATH_CANDIDATES);
+        if (name) {
+          return name;
+        }
+        return searchStringByKeywords(entry, ['name', 'player', 'driver']);
+      }
+      return '';
+    })
+    .filter(Boolean);
+}
+
+function parseDate(value) {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const date = new Date(value * (value > 1_000_000_000 ? 1 : 1000));
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const numeric = Number(trimmed);
+    if (!Number.isNaN(numeric)) {
+      return parseDate(numeric);
+    }
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+}
+
+createModeTabs();
+applyLanguage(state.language);
+setActiveMode(state.activeMode);
+elements.languageButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const lang = button.dataset.lang;
+    if (lang && lang !== state.language) {
+      applyLanguage(lang);
+    }
+  });
+});
+loadMatches();
+
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the match overview with per-mode tabs that expose map selectors and a levelshot preview
- build grouped leaderboards that surface the top 10 entries per map for racing, deathmatch, and objective modes
- refresh translations, styling, and status handling to match the streamlined UI

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68dac292185883249181119aab0cf03e