### PR TITLE
Restore levelshot visibility on success

### DIFF
--- a/index.php
+++ b/index.php
@@ -1882,6 +1882,8 @@ async function updateLevelshot(modeKey, mapData) {
       refs.levelshotFallback.hidden = false;
       return;
     }
+    refs.levelshot.hidden = false;
+    refs.levelshotFallback.hidden = true;
     refs.levelshot.src = resolved.src;
   } catch (error) {
     console.error('Failed to load levelshot', error);


### PR DESCRIPTION
## Summary
- restore the map levelshot image when a resolved asset provides a source and hide the fallback placeholder again

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae5d108dc8324a534c1ce0a0b1ed6