### PR TITLE
Improve server filtering for game-specific listings

### DIFF
--- a/index.php
+++ b/index.php
@@ -4987,17 +4987,27 @@ function build_server_overview(): array
         }
 
         if ($gameFilter !== null) {
-            $infoGame = '';
+            $infoGame = null;
             $info = $status['info'];
             if (isset($info['game']) && is_string($info['game'])) {
                 $infoGame = $info['game'];
             } elseif (isset($info['fs_game']) && is_string($info['fs_game'])) {
                 $infoGame = $info['fs_game'];
-            } elseif ($status['mod'] !== null) {
+            } elseif ($status['mod'] !== null && $status['mod'] !== '') {
                 $infoGame = $status['mod'];
+            } elseif (isset($info['gamename']) && is_string($info['gamename'])) {
+                $infoGame = $info['gamename'];
+            } elseif (isset($info['gametype_name']) && is_string($info['gametype_name'])) {
+                $infoGame = $info['gametype_name'];
             }
 
-            if ($infoGame !== '' && stripos($infoGame, $gameFilter) === false) {
+            if ($infoGame === null) {
+                continue;
+            }
+
+            $infoGame = trim((string) $infoGame);
+
+            if ($infoGame === '' || stripos($infoGame, $gameFilter) === false) {
                 continue;
             }
         }


### PR DESCRIPTION
## Summary
- discard servers without usable game identifiers when a game filter is active
- fall back to gamename and gametype_name fields before rejecting the server entry

## Testing
- curl -sS -H 'Accept: application/json' "http://127.0.0.1:8000/servers?game=q3rally" | jq

------
https://chatgpt.com/codex/tasks/task_e_68e058ad821c83249670a176279279b8